### PR TITLE
feat(majestic-devops): add cloud provider skills and Cloudflare support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -286,8 +286,8 @@
     },
     {
       "name": "majestic-devops",
-      "description": "Infrastructure as Code tools for OpenTofu and Terraform. Includes 1 skill.",
-      "version": "1.0.0",
+      "description": "Infrastructure as Code and DevOps tools. Includes 1 agent and 5 skills for OpenTofu, DigitalOcean, Hetzner Cloud, 1Password CLI, and cloud-init.",
+      "version": "1.1.0",
       "author": {
         "name": "David Paluy",
         "url": "https://github.com/dpaluy",
@@ -304,7 +304,12 @@
         "aws",
         "azure",
         "gcp",
-        "kubernetes",
+        "digitalocean",
+        "hetzner",
+        "cloud-init",
+        "1password",
+        "secrets",
+        "security",
         "cloud"
       ],
       "source": "./plugins/majestic-devops"

--- a/plugins/majestic-devops/CHANGELOG.md
+++ b/plugins/majestic-devops/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2025-12-21
+
+### Added
+
+- `1password-cli-coder` skill for secret management with 1Password CLI
+  - `.op.env` file patterns and integration
+  - Makefile, Docker Compose, and Kamal integration
+  - CI/CD patterns for GitHub Actions
+- `backblaze-coder` skill for Backblaze B2 Cloud Storage
+  - B2 CLI installation and authentication
+  - Bucket, file, and sync operations
+  - Terraform provider with bucket resources
+  - Lifecycle rules for cost optimization
+  - Application key management with minimal permissions
+  - S3-compatible API with AWS CLI and rclone
+  - Bucket encryption (SSE-B2)
+  - File lock for compliance/immutable storage
+  - CORS configuration for web assets
+  - Complete production setup examples
+- `cloud-init-coder` skill for VM provisioning
+  - User and SSH key management
+  - Package installation and service configuration
+  - SSH hardening patterns
+  - Docker setup automation
+- `cloudflare-coder` skill for Cloudflare infrastructure with OpenTofu/Terraform
+  - Zone and DNS record management
+  - SSL/TLS strict mode configuration
+  - WAF custom rules and managed rulesets
+  - Cache rules (modern rulesets over legacy Page Rules)
+  - Redirect rules
+  - Load balancer and origin pools
+  - Origin certificates
+  - Complete production zone examples
+- `digitalocean-coder` skill for DigitalOcean infrastructure
+  - VPC, Droplet, Reserved IP patterns
+  - Managed Database configuration
+  - Firewall rules and security
+  - Complete production stack examples
+- `hetzner-coder` skill for Hetzner Cloud infrastructure
+  - Server types: shared (cx), AMD EPYC (cpx), ARM64 (cax), dedicated (ccx)
+  - Private networks with subnet configuration
+  - Firewalls with label selectors
+  - Load balancers with health checks and TLS
+  - Volumes, snapshots, and backups
+  - Placement groups for high availability
+  - Complete production stack examples
+- `wrangler-coder` skill for Cloudflare Workers and Pages development
+  - wrangler.toml configuration patterns
+  - Multi-environment setup (staging/production)
+  - KV namespace management
+  - D1 database and migrations
+  - R2 object storage bindings
+  - Queues and Durable Objects
+  - Workers AI integration
+  - Secrets management with `wrangler secret`
+  - Local development workflows
+  - Pages Functions patterns
+  - Deployment, logs, and rollback workflows
+- `infra-security-review` agent for IaC security audits
+  - State backend security checks
+  - Secret exposure detection
+  - Network security analysis
+  - Compliance-focused reporting
+- `makefile-automation.md` resource for `opentofu-coder`
+  - Workspace/stack automation patterns
+  - Secret loading integration
+  - Multi-stack operations
+- Plugin README.md documentation
+
 ## [1.0.0] - 2025-12-20
 
 ### Added

--- a/plugins/majestic-devops/README.md
+++ b/plugins/majestic-devops/README.md
@@ -1,0 +1,452 @@
+# Majestic DevOps
+
+Infrastructure-as-Code and DevOps workflows for Claude Code.
+
+## Overview
+
+This plugin provides AI-powered assistance for:
+- Infrastructure provisioning with OpenTofu/Terraform
+- Cloud provider configuration (AWS, Backblaze B2, Cloudflare, DigitalOcean, Hetzner, GCP)
+- Cloudflare Workers, Pages, D1, R2, and KV with Wrangler
+- Backblaze B2 Cloud Storage with B2 CLI and S3-compatible API
+- Secret management with 1Password CLI
+- VM provisioning with cloud-init
+- Infrastructure security review
+
+## Getting Started
+
+### Prerequisites
+
+1. **OpenTofu or Terraform installed**
+   ```bash
+   # macOS
+   brew install opentofu
+
+   # Linux (Debian/Ubuntu)
+   curl -fsSL https://get.opentofu.org/install-opentofu.sh | sh
+
+   # Or Terraform (macOS)
+   brew install terraform
+
+   # Or Terraform (Linux)
+   # See https://developer.hashicorp.com/terraform/install
+   ```
+
+2. **Cloud provider credentials configured**
+   ```bash
+   # AWS
+   export AWS_ACCESS_KEY_ID="your-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret"
+
+   # Backblaze B2
+   export B2_APPLICATION_KEY_ID="your-key-id"
+   export B2_APPLICATION_KEY="your-application-key"
+
+   # Cloudflare
+   export CLOUDFLARE_API_TOKEN="your-api-token"
+
+   # DigitalOcean
+   export DIGITALOCEAN_TOKEN="your-token"
+
+   # Hetzner
+   export HCLOUD_TOKEN="your-token"
+   ```
+
+3. **Wrangler CLI (for Cloudflare Workers/Pages)**
+   ```bash
+   npm install -g wrangler
+   wrangler login
+   ```
+
+4. **B2 CLI (for Backblaze B2 Cloud Storage)**
+   ```bash
+   # macOS
+   brew install b2-tools
+
+   # Linux (Debian/Ubuntu)
+   sudo apt install backblaze-b2
+
+   # Linux (via pip)
+   pip install b2
+
+   # Authorize
+   b2 authorize-account <keyId> <applicationKey>
+   ```
+
+5. **1Password CLI (optional but recommended)**
+   ```bash
+   brew install 1password-cli
+   op signin
+   ```
+
+   **Multiple accounts?** Use `--account` or `OP_ACCOUNT` to select:
+   ```bash
+   op account list                              # List configured accounts
+   op run --account acme.1password.com -- ...  # Use specific account
+   export OP_ACCOUNT=acme.1password.com        # Set default for session
+   ```
+
+### Quick Start: Create Infrastructure
+
+1. **Initialize a new IaC project:**
+   ```
+   Help me set up infrastructure for my Rails app on DigitalOcean
+   ```
+
+2. **Claude will create:**
+   - `providers.tf` - Provider configuration
+   - `main.tf` - Core infrastructure resources
+   - `variables.tf` - Input variables
+   - `outputs.tf` - Output values
+   - `Makefile` - Automation commands
+
+3. **Deploy your infrastructure:**
+   ```bash
+   make plan production/core
+   make apply production/core
+   ```
+
+### Project Structure Pattern
+
+The plugin follows a workspace/stack directory pattern:
+
+```
+infrastructure/
+├── Makefile                    # Automation commands
+├── .op.env                     # 1Password secret references
+├── providers.tf                # Shared provider config
+├── shared_variables.tf         # Shared variable validation
+├── shared/
+│   └── backend/                # State backend (S3 + DynamoDB)
+│       ├── main.tf
+│       └── backend.tf
+├── production/
+│   └── core/                   # Production infrastructure
+│       ├── main.tf
+│       ├── variables.tf
+│       └── outputs.tf
+└── staging/
+    └── core/                   # Staging infrastructure
+        └── ...
+```
+
+### Common Workflows
+
+**Create a new environment:**
+```
+Set up a staging environment matching production but with smaller instances
+```
+
+**Add a database:**
+```
+Add a managed PostgreSQL database to my production stack with private networking
+```
+
+**Security review:**
+```
+Review my infrastructure code for security issues
+```
+
+**Set up secrets:**
+```
+Help me configure 1Password CLI for loading deployment credentials
+```
+
+## Skills
+
+### opentofu-coder
+
+Write Infrastructure-as-Code using OpenTofu (open-source Terraform fork).
+
+**Triggers on:**
+- Creating `.tf` files
+- Managing cloud infrastructure
+- Configuring providers
+- Designing reusable modules
+
+**Includes:**
+- HCL syntax patterns
+- State management with encryption
+- Module design best practices
+- Provider configuration examples
+- Makefile automation workflows
+
+### 1password-cli-coder
+
+Integrate 1Password CLI (`op`) for secret management.
+
+**Triggers on:**
+- Loading secrets for infrastructure
+- Setting up deployment credentials
+- Configuring local development environments
+
+**Includes:**
+- `.op.env` file patterns
+- Makefile integration
+- Docker Compose secret injection
+- Kamal deployment secrets
+- CI/CD integration (GitHub Actions)
+
+### cloud-init-coder
+
+Write cloud-init configurations for VM provisioning.
+
+**Triggers on:**
+- Creating `user_data` blocks
+- Writing cloud-init YAML
+- Setting up new instances
+
+**Includes:**
+- User and SSH key management
+- Package installation
+- SSH hardening
+- Docker setup
+- Firewall configuration
+- Systemd service creation
+
+### digitalocean-coder
+
+Provision DigitalOcean infrastructure.
+
+**Triggers on:**
+- Creating DO resources
+- Configuring Droplets, VPCs, Databases
+- Setting up firewalls
+
+**Includes:**
+- VPC networking patterns
+- Droplet provisioning with cloud-init
+- Reserved IP management
+- Database cluster configuration
+- Firewall rules
+- Complete production stack examples
+
+### hetzner-coder
+
+Provision Hetzner Cloud infrastructure.
+
+**Triggers on:**
+- Creating Hetzner resources
+- Configuring servers, networks, load balancers
+- Setting up firewalls and volumes
+
+**Includes:**
+- Server types: shared (cx), AMD EPYC (cpx), ARM64 (cax), dedicated (ccx)
+- Private networks with subnet configuration
+- Firewalls with label selectors
+- Load balancers with health checks and TLS
+- Volumes, snapshots, and backups
+- Placement groups for high availability
+- Complete production stack examples
+
+### cloudflare-coder
+
+Provision Cloudflare infrastructure with OpenTofu/Terraform.
+
+**Triggers on:**
+- Managing DNS records
+- Configuring SSL/TLS settings
+- Setting up WAF and firewall rules
+- Creating cache rules and Page Rules
+- Configuring load balancers
+
+**Includes:**
+- Zone and DNS management
+- SSL/TLS strict mode configuration
+- WAF custom rules and managed rulesets
+- Cache rules (modern rulesets)
+- Redirect rules
+- Load balancer configuration
+- Origin certificates
+- Complete production zone examples
+
+### wrangler-coder
+
+Develop Cloudflare Workers and Pages with Wrangler CLI.
+
+**Triggers on:**
+- Creating Workers or Pages projects
+- Configuring wrangler.toml
+- Setting up D1, R2, KV, or Queues
+- Deploying to Cloudflare
+
+**Includes:**
+- wrangler.toml configuration patterns
+- Multi-environment setup (staging/production)
+- KV namespace management
+- D1 database and migrations
+- R2 object storage
+- Queues and Durable Objects
+- Workers AI integration
+- Secrets management
+- Local development workflows
+- Deployment and rollback patterns
+
+### backblaze-coder
+
+Manage Backblaze B2 Cloud Storage with B2 CLI and Terraform.
+
+**Triggers on:**
+- Creating B2 buckets
+- Configuring lifecycle rules
+- Setting up application keys
+- Syncing files to/from B2
+- Using S3-compatible API
+
+**Includes:**
+- B2 CLI operations (sync, upload, download)
+- Terraform provider configuration
+- Bucket management with encryption
+- Lifecycle rules for cost optimization
+- Application key management
+- S3-compatible API with AWS CLI and rclone
+- CORS configuration for web assets
+- File lock for compliance
+- Complete production setup examples
+
+## Agents
+
+### infra-security-review
+
+Review IaC for security vulnerabilities and misconfigurations.
+
+**Checks for:**
+- State backend security (encryption, locking, public access)
+- Secret exposure (hardcoded credentials)
+- Network security (SSH exposure, database access)
+- Compute hardening (root login, password auth)
+- Storage security (public buckets, encryption)
+
+**Usage:**
+```
+Review my infrastructure code for security issues
+```
+
+## Installation
+
+Add to your Claude Code settings:
+
+```json
+{
+  "plugins": [
+    "majestic-devops@majestic-marketplace"
+  ]
+}
+```
+
+## Usage Examples
+
+### Create Infrastructure on DigitalOcean
+
+```
+Set up a production stack on DigitalOcean with:
+- VPC for network isolation
+- Droplet with Docker
+- Managed PostgreSQL
+- Firewall rules
+```
+
+### Create Infrastructure on Hetzner
+
+```
+Set up a cost-effective production stack on Hetzner with:
+- ARM64 servers for best price/performance
+- Private network
+- Load balancer with health checks
+- Placement group for high availability
+```
+
+### Review Security
+
+```
+Review my Terraform code for security issues
+```
+
+### Set Up Secrets
+
+```
+Help me configure 1Password CLI for my infrastructure deployments
+```
+
+### Configure Cloudflare Zone
+
+```
+Set up my domain on Cloudflare with:
+- Strict SSL/TLS mode
+- WAF with managed rulesets
+- Cache rules for static assets
+- Redirect www to apex
+```
+
+### Create Cloudflare Worker
+
+```
+Create a Cloudflare Worker API with:
+- D1 database for users
+- KV for caching
+- Multi-environment config (staging/production)
+```
+
+### Deploy to Cloudflare Pages
+
+```
+Set up Cloudflare Pages deployment for my React app with:
+- API functions in /api/*
+- D1 database binding
+- Environment-specific secrets
+```
+
+### Set Up Backblaze B2 Storage
+
+```
+Set up Backblaze B2 storage for my app with:
+- Private bucket for user uploads with encryption
+- Public bucket for static assets with CORS
+- Lifecycle rules to auto-delete temp files
+- Application keys with minimal permissions
+```
+
+### Sync Backups to Backblaze
+
+```
+Help me set up automated backups to Backblaze B2:
+- Daily database dumps synced with b2 sync
+- 30-day retention with lifecycle rules
+- Encrypted at rest
+```
+
+## File Structure
+
+```
+majestic-devops/
+├── skills/
+│   ├── opentofu-coder/
+│   │   ├── SKILL.md
+│   │   └── resources/
+│   │       ├── hcl-patterns.md
+│   │       ├── state-management.md
+│   │       ├── provider-examples.md
+│   │       └── makefile-automation.md
+│   ├── 1password-cli-coder/
+│   │   └── SKILL.md
+│   ├── backblaze-coder/
+│   │   └── SKILL.md
+│   ├── cloud-init-coder/
+│   │   └── SKILL.md
+│   ├── cloudflare-coder/
+│   │   └── SKILL.md
+│   ├── digitalocean-coder/
+│   │   └── SKILL.md
+│   ├── hetzner-coder/
+│   │   └── SKILL.md
+│   └── wrangler-coder/
+│       └── SKILL.md
+├── agents/
+│   └── infra-security-review.md
+├── README.md
+└── CHANGELOG.md
+```
+
+## Contributing
+
+See the main [majestic-marketplace](https://github.com/majestic-marketplace) repository for contribution guidelines.

--- a/plugins/majestic-devops/agents/infra-security-review.md
+++ b/plugins/majestic-devops/agents/infra-security-review.md
@@ -1,0 +1,197 @@
+---
+name: infra-security-review
+description: Review Infrastructure-as-Code for security vulnerabilities, misconfigurations, and hardening opportunities. Covers Terraform/OpenTofu, cloud-init, and cloud provider resources.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Infrastructure Security Review
+
+You are an infrastructure security specialist reviewing IaC code for security issues, misconfigurations, and hardening opportunities.
+
+## Review Process
+
+1. **Discover IaC Files**
+   - Find all `.tf`, `.tfvars`, and cloud-init files
+   - Identify provider types (AWS, DigitalOcean, GCP, Azure)
+   - Check for state backend configuration
+
+2. **Run Security Checks**
+   - Execute `tofu validate` if available
+   - Search for hardcoded secrets
+   - Analyze resource configurations
+
+3. **Generate Report**
+   - Categorize findings by severity
+   - Provide specific remediation steps
+   - Include code snippets for fixes
+
+## Security Checklist
+
+### State Backend Security
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| S3 bucket without encryption | Critical | `encrypt = false` or missing |
+| Missing state locking | High | No DynamoDB table configured |
+| Public bucket policy | Critical | `block_public_*` not all true |
+| Missing versioning | Medium | `versioning` not enabled |
+
+### Secret Exposure
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| Hardcoded AWS keys | Critical | `AKIA[0-9A-Z]{16}` |
+| Hardcoded passwords | Critical | `password\s*=\s*"[^"]+[^}]"` |
+| Database credentials in code | Critical | `DATABASE_URL` with password |
+| API keys in variables | High | `api_key`, `secret_key` defaults |
+
+### Network Security
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| SSH open to world | Critical | `0.0.0.0/0` on port 22 |
+| Database publicly accessible | Critical | Missing `private_network_uuid` |
+| Wide CIDR ranges | Medium | `/8`, `/16` on public resources |
+| Missing firewall | High | Droplet without firewall resource |
+
+### Compute Security
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| Root login enabled | High | `PermitRootLogin yes` in cloud-init |
+| Password auth enabled | Medium | `PasswordAuthentication yes` |
+| Missing SSH hardening | Low | No `ClientAliveInterval` config |
+| No monitoring | Low | `monitoring = false` |
+
+### Database Security
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| Public database access | Critical | No database firewall rules |
+| No VPC attachment | High | Missing `private_network_uuid` |
+| Weak version | Medium | Old database engine versions |
+| Single node for production | Low | `node_count = 1` in prod |
+
+### Storage Security
+
+| Check | Severity | Pattern |
+|-------|----------|---------|
+| Public S3 buckets | Critical | `acl = "public-read"` |
+| Missing encryption | High | No SSE configuration |
+| No access logging | Medium | Missing access log bucket |
+
+## Search Patterns
+
+Use these grep patterns to find issues:
+
+```bash
+# Hardcoded secrets
+grep -rE 'AKIA[0-9A-Z]{16}' *.tf
+grep -rE 'password\s*=\s*"[^$][^"]*"' *.tf
+grep -rE 'secret.*=\s*"[^$][^"]*"' *.tf
+
+# Network exposure
+grep -rE 'source_addresses.*0\.0\.0\.0/0.*port.*22' *.tf
+grep -rE 'cidr_blocks.*0\.0\.0\.0/0' *.tf
+
+# State security
+grep -rE 'encrypt\s*=\s*false' *.tf
+grep -rE 'block_public_acls\s*=\s*false' *.tf
+
+# Cloud-init issues
+grep -rE 'PermitRootLogin\s+yes' *.tf *.yaml
+grep -rE 'PasswordAuthentication\s+yes' *.tf *.yaml
+```
+
+## Report Format
+
+```markdown
+# Infrastructure Security Review
+
+**Repository:** [name]
+**Date:** [date]
+**Files Reviewed:** [count]
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | X |
+| High | X |
+| Medium | X |
+| Low | X |
+
+## Critical Findings
+
+### [CRIT-001] SSH Open to World
+
+**File:** `production/core/main.tf:62`
+**Resource:** `digitalocean_firewall.app`
+
+**Issue:**
+SSH (port 22) is accessible from any IP address.
+
+**Current:**
+```hcl
+inbound_rule {
+  protocol         = "tcp"
+  port_range       = "22"
+  source_addresses = ["0.0.0.0/0"]
+}
+```
+
+**Remediation:**
+Restrict SSH to known IP addresses or VPN CIDR.
+
+```hcl
+inbound_rule {
+  protocol         = "tcp"
+  port_range       = "22"
+  source_addresses = var.ssh_allowed_ips  # ["203.0.113.0/24"]
+}
+```
+
+## High Findings
+
+### [HIGH-001] Database Without VPC
+
+...
+
+## Recommendations
+
+1. **Immediate:** Fix all Critical and High findings before deployment
+2. **Short-term:** Implement Medium findings within 30 days
+3. **Long-term:** Address Low findings in next infrastructure review
+
+## Compliance Notes
+
+- [ ] State encryption enabled (SOC 2)
+- [ ] No hardcoded credentials (PCI-DSS)
+- [ ] Network segmentation in place (HIPAA)
+- [ ] Access logging enabled (all frameworks)
+```
+
+## Execution
+
+When invoked:
+
+1. Find all IaC files:
+```bash
+find . -name "*.tf" -o -name "*.tfvars" -o -name "cloud-init*"
+```
+
+2. Run validation if tofu available:
+```bash
+tofu validate 2>&1 || true
+```
+
+3. Search for each security pattern
+
+4. Read flagged files for context
+
+5. Generate structured report with:
+   - Severity rating
+   - File and line number
+   - Current code snippet
+   - Remediation code snippet
+   - Compliance implications

--- a/plugins/majestic-devops/skills/1password-cli-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/1password-cli-coder/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: 1password-cli-coder
+description: This skill guides integrating 1Password CLI (op) for secret management in development workflows. Use when loading secrets for infrastructure, deployments, or local development.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# 1Password CLI Coder
+
+## Overview
+
+The 1Password CLI (`op`) provides secure secret injection into development workflows without exposing credentials in code, environment files, or shell history.
+
+## Core Patterns
+
+### Secret Reference Format
+
+```
+op://<vault>/<item>/<field>
+```
+
+Examples:
+```
+op://Development/AWS/access_key_id
+op://Production/Database/password
+op://Shared/Stripe/secret_key
+```
+
+### Environment File (.op.env)
+
+Create `.op.env` in project root:
+
+```bash
+# AWS credentials
+AWS_ACCESS_KEY_ID=op://Infrastructure/AWS/access_key_id
+AWS_SECRET_ACCESS_KEY=op://Infrastructure/AWS/secret_access_key
+AWS_REGION=op://Infrastructure/AWS/region
+
+# DigitalOcean
+DIGITALOCEAN_TOKEN=op://Infrastructure/DigitalOcean/api_token
+
+# Database
+DATABASE_URL=op://Production/PostgreSQL/connection_string
+
+# API Keys
+STRIPE_SECRET_KEY=op://Production/Stripe/secret_key
+OPENAI_API_KEY=op://Development/OpenAI/api_key
+```
+
+**Critical:** Add to `.gitignore`:
+```gitignore
+# 1Password - NEVER commit
+.op.env
+*.op.env
+```
+
+### Running Commands with Secrets
+
+```bash
+# Single command
+op run --env-file=.op.env -- terraform plan
+
+# With environment variable prefix
+op run --env-file=.op.env -- rails server
+
+# Inline secret reference
+op run -- printenv DATABASE_URL
+```
+
+## Integration Patterns
+
+### Makefile Integration
+
+```makefile
+OP ?= op
+OP_ENV_FILE ?= .op.env
+
+# Prefix for all commands needing secrets
+CMD = $(OP) run --env-file=$(OP_ENV_FILE) --
+
+deploy:
+	$(CMD) kamal deploy
+
+console:
+	$(CMD) rails console
+
+migrate:
+	$(CMD) rails db:migrate
+```
+
+### Docker Compose
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    build: .
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+```
+
+```bash
+# Run with secrets injected
+op run --env-file=.op.env -- docker compose up
+```
+
+### Kamal Deployment
+
+```yaml
+# config/deploy.yml
+env:
+  secret:
+    - RAILS_MASTER_KEY
+    - DATABASE_URL
+    - REDIS_URL
+```
+
+```bash
+# .kamal/secrets (loaded by Kamal)
+RAILS_MASTER_KEY=$(op read "op://Production/Rails/master_key")
+DATABASE_URL=$(op read "op://Production/PostgreSQL/url")
+REDIS_URL=$(op read "op://Production/Redis/url")
+```
+
+### CI/CD (GitHub Actions)
+
+```yaml
+# .github/workflows/deploy.yml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_ACCESS_KEY_ID: op://CI/AWS/access_key_id
+          AWS_SECRET_ACCESS_KEY: op://CI/AWS/secret_access_key
+
+      - run: terraform apply -auto-approve
+```
+
+## CLI Commands
+
+### Reading Secrets
+
+```bash
+# Read single field
+op read "op://Vault/Item/field"
+
+# Read with output format
+op read "op://Vault/Item/field" --format json
+
+# Read to file (for certificates, keys)
+op read "op://Vault/TLS/private_key" > /tmp/key.pem
+chmod 600 /tmp/key.pem
+```
+
+### Injecting into Commands
+
+```bash
+# Single secret inline
+DATABASE_URL=$(op read "op://Production/DB/url") rails db:migrate
+
+# Multiple secrets via env file
+op run --env-file=.op.env -- ./deploy.sh
+
+# With account specification
+op run --account my-team --env-file=.op.env -- terraform apply
+```
+
+### Managing Items
+
+```bash
+# List vaults
+op vault list
+
+# List items in vault
+op item list --vault Infrastructure
+
+# Get item details
+op item get "AWS" --vault Infrastructure
+
+# Create item
+op item create \
+  --category login \
+  --vault Infrastructure \
+  --title "New Service" \
+  --field username=admin \
+  --field password=secret123
+```
+
+## Project Setup
+
+### Initial Configuration
+
+```bash
+# Sign in (creates session)
+op signin
+
+# Verify access
+op vault list
+
+# Create project env file
+cat > .op.env << 'EOF'
+# Infrastructure secrets
+AWS_ACCESS_KEY_ID=op://Infrastructure/AWS/access_key_id
+AWS_SECRET_ACCESS_KEY=op://Infrastructure/AWS/secret_access_key
+
+# Application secrets
+DATABASE_URL=op://Production/Database/url
+REDIS_URL=op://Production/Redis/url
+EOF
+
+# Test secret loading
+op run --env-file=.op.env -- env | grep -E '^(AWS|DATABASE|REDIS)'
+```
+
+### Vault Organization
+
+Recommended vault structure:
+
+| Vault | Purpose | Access |
+|-------|---------|--------|
+| `Infrastructure` | Cloud provider credentials | DevOps team |
+| `Production` | Production app secrets | Deploy systems |
+| `Staging` | Staging environment | Dev team |
+| `Development` | Local dev secrets | Individual devs |
+| `Shared` | Cross-team API keys | All teams |
+
+## Security Best Practices
+
+### DO
+
+- Use `.op.env` files for project-specific secret mapping
+- Add all `.op.env` variants to `.gitignore`
+- Use service accounts for CI/CD (not personal accounts)
+- Scope vault access by team/environment
+- Rotate secrets regularly via 1Password
+
+### DON'T
+
+- Never commit `.op.env` files
+- Never use `op read` output in logs or echo statements
+- Never store session tokens in scripts
+- Avoid hardcoding vault/item names - use variables
+
+### Audit Logging
+
+```bash
+# Check recent access events
+op events-api
+
+# Specific vault events
+op audit-events list --vault Production
+```
+
+## Troubleshooting
+
+### Session Expired
+
+```bash
+# Re-authenticate
+op signin
+
+# Check current session
+op whoami
+```
+
+### Item Not Found
+
+```bash
+# Verify vault access
+op vault list
+
+# Search for item
+op item list --vault Infrastructure | grep -i aws
+
+# Check exact field names
+op item get "AWS" --vault Infrastructure --format json | jq '.fields[].label'
+```
+
+### Permission Denied
+
+```bash
+# Check account permissions
+op vault list
+
+# Verify specific vault access
+op vault get Infrastructure
+```
+
+## Multiple Accounts
+
+Many users have separate personal and work 1Password accounts. The CLI supports switching between them.
+
+### List Configured Accounts
+
+```bash
+op account list
+```
+
+Output:
+```
+USER ID                          URL
+-----------------------------    --------------------------
+A3BCDEFGHIJKLMNOPQRSTUVWX       my.1password.com
+B4CDEFGHIJKLMNOPQRSTUVWXY       acme.1password.com
+```
+
+### Specify Account per Command
+
+Use `--account` with either the sign-in address or account ID:
+
+```bash
+# Using sign-in address
+op vault list --account my.1password.com
+op item get "AWS" --account acme.1password.com
+
+# Using account ID
+op vault list --account A3BCDEFGHIJKLMNOPQRSTUVWX
+```
+
+### Set Default Account (Environment Variable)
+
+Set `OP_ACCOUNT` to choose default for all commands in that shell:
+
+```bash
+export OP_ACCOUNT=acme.1password.com
+op vault list            # Uses acme.1password.com
+op item get "API Key"    # Uses acme.1password.com
+```
+
+`--account` flag **overrides** `OP_ACCOUNT` for a single command.
+
+### Multiple Accounts with op run
+
+```bash
+# Specify account explicitly
+op run --account acme.1password.com --env-file=.op.env.work -- ./deploy.sh
+
+# Or set environment variable first
+export OP_ACCOUNT=my.1password.com
+op run --env-file=.op.env.personal -- ./start-local-dev.sh
+```
+
+### Cross-Account Workflows
+
+When scripts need secrets from different accounts:
+
+```bash
+# Script using work account
+export OP_ACCOUNT=acme.1password.com
+WORK_DB=$(op read "op://Production/Database/url")
+
+# Switch to personal for specific command
+PERSONAL_KEY=$(op read "op://Personal/GitHub/token" --account my.1password.com)
+```
+
+### Makefile with Account Selection
+
+```makefile
+# Default to work account
+OP_ACCOUNT ?= acme.1password.com
+OP ?= op
+OP_ENV_FILE ?= .op.env
+
+CMD = OP_ACCOUNT=$(OP_ACCOUNT) $(OP) run --env-file=$(OP_ENV_FILE) --
+
+deploy:
+	$(CMD) kamal deploy
+
+# Personal account for local dev
+dev:
+	OP_ACCOUNT=my.1password.com $(OP) run --env-file=.op.env.personal -- rails server
+
+# Usage:
+# make deploy                           # Uses work account
+# make deploy OP_ACCOUNT=my.1password.com  # Override account
+# make dev                              # Uses personal account
+```
+
+### Best Practices for Multiple Accounts
+
+**DO:**
+- Always use `--account` or `OP_ACCOUNT` in scripts (don't rely on "last signed in")
+- Use work accounts for CI/CD, personal for local dev
+- Create separate `.op.env` files per account context
+
+**DON'T:**
+- Rely on "last signed in" account in automation (brittle)
+- Mix account contexts in single env file
+
+### Account-Specific Env Files
+
+```bash
+# .op.env.work (uses work account vaults)
+AWS_ACCESS_KEY_ID=op://Work-Infrastructure/AWS/access_key_id
+DATABASE_URL=op://Work-Production/Database/url
+
+# .op.env.personal (uses personal account vaults)
+GITHUB_TOKEN=op://Personal/GitHub/token
+OPENAI_API_KEY=op://Personal/OpenAI/api_key
+```
+
+```makefile
+# Makefile with account + env file pairing
+work-deploy:
+	op run --account acme.1password.com --env-file=.op.env.work -- ./deploy.sh
+
+personal-dev:
+	op run --account my.1password.com --env-file=.op.env.personal -- ./dev.sh
+```
+
+## Multi-Environment Pattern
+
+```bash
+# .op.env.production
+DATABASE_URL=op://Production/Database/url
+REDIS_URL=op://Production/Redis/url
+
+# .op.env.staging
+DATABASE_URL=op://Staging/Database/url
+REDIS_URL=op://Staging/Redis/url
+
+# .op.env.development
+DATABASE_URL=op://Development/Database/url
+REDIS_URL=op://Development/Redis/url
+```
+
+```makefile
+ENV ?= development
+OP_ENV_FILE = .op.env.$(ENV)
+
+deploy:
+	op run --env-file=$(OP_ENV_FILE) -- kamal deploy
+
+# Usage: make deploy ENV=production
+```

--- a/plugins/majestic-devops/skills/backblaze-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/backblaze-coder/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: backblaze-coder
+description: This skill guides Backblaze B2 Cloud Storage integration with OpenTofu/Terraform and B2 CLI. Use when managing B2 buckets, application keys, file uploads, lifecycle rules, or S3-compatible storage.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# Backblaze Coder
+
+## Overview
+
+Backblaze B2 is an affordable S3-compatible cloud storage service. This skill covers B2 CLI usage, Terraform provisioning, and S3-compatible API integration.
+
+## B2 CLI Installation
+
+```bash
+# macOS
+brew install b2-tools
+
+# Linux (Debian/Ubuntu)
+sudo apt install backblaze-b2
+
+# Linux (via pip)
+pip install b2
+
+# Verify installation
+b2 version
+```
+
+## CLI Authentication
+
+```bash
+# Authorize with application key (preferred)
+b2 authorize-account <applicationKeyId> <applicationKey>
+
+# Or with 1Password
+b2 authorize-account $(op read "op://Infrastructure/Backblaze/key_id") \
+                     $(op read "op://Infrastructure/Backblaze/application_key")
+
+# Credentials stored in ~/.b2_account_info (SQLite)
+# Override with B2_ACCOUNT_INFO env var
+```
+
+**Application Key Capabilities:**
+
+| Capability | Operations |
+|------------|------------|
+| `listBuckets` | List buckets (minimum required) |
+| `listFiles` | List files in bucket |
+| `readFiles` | Download files |
+| `writeFiles` | Upload files |
+| `deleteFiles` | Delete files |
+| `writeBucketRetentions` | Modify retention settings |
+| `readBucketEncryption` | Read encryption settings |
+| `writeBucketEncryption` | Modify encryption settings |
+
+## B2 CLI Operations
+
+### Bucket Management
+
+```bash
+# List buckets
+b2 bucket list
+
+# Create bucket (allPrivate or allPublic)
+b2 bucket create my-bucket allPrivate
+
+# Create with lifecycle rules
+b2 bucket create my-bucket allPrivate \
+  --lifecycle-rules '[{"daysFromHidingToDeleting": 30, "fileNamePrefix": "logs/"}]'
+
+# Delete bucket (must be empty)
+b2 bucket delete my-bucket
+
+# Update bucket type
+b2 bucket update my-bucket allPrivate
+```
+
+### File Operations
+
+```bash
+# List files in bucket
+b2 ls my-bucket
+b2 ls my-bucket path/to/folder/
+
+# Upload file
+b2 upload-file my-bucket local-file.txt remote/path/file.txt
+
+# Upload with content type
+b2 upload-file --content-type "application/json" my-bucket data.json data.json
+
+# Download file
+b2 download-file-by-name my-bucket remote/path/file.txt local-file.txt
+
+# Download by file ID
+b2 download-file-by-id <fileId> local-file.txt
+
+# Delete file
+b2 rm my-bucket path/to/file.txt
+
+# Delete all versions
+b2 rm --recursive --versions my-bucket path/to/folder/
+```
+
+### Sync Operations
+
+```bash
+# Sync local to B2
+b2 sync /local/path b2://my-bucket/prefix/
+
+# Sync B2 to local
+b2 sync b2://my-bucket/prefix/ /local/path
+
+# Sync B2 to B2 (copy between buckets)
+b2 sync b2://source-bucket/ b2://dest-bucket/
+
+# Sync with options
+b2 sync /local/path b2://my-bucket/ \
+  --threads 20 \
+  --delete \
+  --keep-days 30 \
+  --exclude-regex ".*\.tmp$"
+
+# Compare by size and modification time
+b2 sync --compare-versions size /local/path b2://my-bucket/
+```
+
+**Sync Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--threads N` | Parallel threads (default 10, max 99) |
+| `--delete` | Delete files not in source |
+| `--keep-days N` | Keep old versions for N days |
+| `--replace-newer` | Replace if source is newer |
+| `--skip-newer` | Skip if dest is newer |
+| `--exclude-regex` | Exclude matching files |
+| `--include-regex` | Include only matching files |
+| `--no-progress` | Disable progress (for scripts) |
+
+### Application Keys
+
+```bash
+# List keys
+b2 key list
+
+# Create key with specific capabilities
+b2 key create my-app-key listBuckets,listFiles,readFiles,writeFiles
+
+# Create key restricted to bucket
+b2 key create my-app-key listBuckets,listFiles,readFiles \
+  --bucket my-bucket \
+  --name-prefix "uploads/"
+
+# Delete key
+b2 key delete <applicationKeyId>
+```
+
+## Terraform Provider
+
+### Provider Setup
+
+```hcl
+terraform {
+  required_providers {
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.8"
+    }
+  }
+}
+
+provider "b2" {
+  # Credentials from environment:
+  # B2_APPLICATION_KEY_ID
+  # B2_APPLICATION_KEY
+}
+```
+
+### Authentication
+
+```bash
+# Set environment variables
+export B2_APPLICATION_KEY_ID="your-key-id"
+export B2_APPLICATION_KEY="your-application-key"
+
+# Or with 1Password
+B2_APPLICATION_KEY_ID=op://Infrastructure/Backblaze/key_id
+B2_APPLICATION_KEY=op://Infrastructure/Backblaze/application_key
+```
+
+### Bucket Resource
+
+```hcl
+resource "b2_bucket" "storage" {
+  bucket_name = "my-app-storage"
+  bucket_type = "allPrivate"
+
+  bucket_info = {
+    environment = "production"
+    application = "my-app"
+  }
+
+  lifecycle_rules {
+    file_name_prefix              = "logs/"
+    days_from_hiding_to_deleting  = 30
+    days_from_uploading_to_hiding = 90
+  }
+
+  lifecycle_rules {
+    file_name_prefix              = "temp/"
+    days_from_hiding_to_deleting  = 1
+    days_from_uploading_to_hiding = 7
+  }
+}
+
+output "bucket_id" {
+  value = b2_bucket.storage.bucket_id
+}
+```
+
+### Bucket with CORS
+
+```hcl
+resource "b2_bucket" "web_assets" {
+  bucket_name = "my-web-assets"
+  bucket_type = "allPublic"
+
+  cors_rules {
+    cors_rule_name   = "allowWebApp"
+    allowed_origins  = ["https://myapp.com", "https://www.myapp.com"]
+    allowed_headers  = ["*"]
+    allowed_operations = ["s3_get", "s3_head"]
+    expose_headers   = ["x-bz-content-sha1"]
+    max_age_seconds  = 3600
+  }
+}
+```
+
+### Bucket with Encryption
+
+```hcl
+resource "b2_bucket" "encrypted" {
+  bucket_name = "my-encrypted-bucket"
+  bucket_type = "allPrivate"
+
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
+}
+```
+
+### Bucket with File Lock (Immutable)
+
+```hcl
+resource "b2_bucket" "compliance" {
+  bucket_name = "compliance-records"
+  bucket_type = "allPrivate"
+
+  file_lock_configuration {
+    is_file_lock_enabled = true
+
+    default_retention {
+      mode = "governance"
+      period {
+        duration = 365
+        unit     = "days"
+      }
+    }
+  }
+}
+```
+
+### Application Key Resource
+
+```hcl
+resource "b2_application_key" "app" {
+  key_name     = "my-app-key"
+  capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles"]
+  bucket_id    = b2_bucket.storage.bucket_id
+  name_prefix  = "uploads/"
+}
+
+output "application_key_id" {
+  value = b2_application_key.app.application_key_id
+}
+
+output "application_key" {
+  value     = b2_application_key.app.application_key
+  sensitive = true
+}
+```
+
+### Data Sources
+
+```hcl
+# Get account info
+data "b2_account_info" "current" {}
+
+output "account_id" {
+  value = data.b2_account_info.current.account_id
+}
+
+# Get bucket by name
+data "b2_bucket" "existing" {
+  bucket_name = "my-existing-bucket"
+}
+
+output "bucket_id" {
+  value = data.b2_bucket.existing.bucket_id
+}
+```
+
+### Upload File
+
+```hcl
+resource "b2_bucket_file" "config" {
+  bucket_id    = b2_bucket.storage.bucket_id
+  file_name    = "config/settings.json"
+  source       = "${path.module}/files/settings.json"
+  content_type = "application/json"
+}
+
+# Upload with file info metadata
+resource "b2_bucket_file" "data" {
+  bucket_id = b2_bucket.storage.bucket_id
+  file_name = "data/export.csv"
+  source    = "${path.module}/files/export.csv"
+
+  file_info = {
+    exported_at = timestamp()
+    version     = "1.0"
+  }
+}
+```
+
+## S3-Compatible API
+
+Backblaze B2 supports S3-compatible API endpoints for tools like AWS CLI, rclone, and S3 SDKs.
+
+### S3 Endpoint
+
+```bash
+# Format: s3.<region>.backblazeb2.com
+# Example regions: us-west-004, us-west-002, eu-central-003
+
+# Get your endpoint from B2 console or:
+b2 get-account-info
+```
+
+### AWS CLI Configuration
+
+```bash
+# Configure AWS CLI for B2
+aws configure --profile backblaze
+
+# Enter:
+# AWS Access Key ID: Your B2 applicationKeyId
+# AWS Secret Access Key: Your B2 applicationKey
+# Default region name: us-west-004
+# Default output format: json
+```
+
+```ini
+# ~/.aws/config
+[profile backblaze]
+region = us-west-004
+output = json
+
+# ~/.aws/credentials
+[backblaze]
+aws_access_key_id = your-key-id
+aws_secret_access_key = your-application-key
+```
+
+### AWS CLI Usage
+
+```bash
+# List buckets
+aws --profile backblaze --endpoint-url https://s3.us-west-004.backblazeb2.com s3 ls
+
+# List objects
+aws --profile backblaze --endpoint-url https://s3.us-west-004.backblazeb2.com \
+  s3 ls s3://my-bucket/
+
+# Upload file
+aws --profile backblaze --endpoint-url https://s3.us-west-004.backblazeb2.com \
+  s3 cp local-file.txt s3://my-bucket/path/file.txt
+
+# Sync directory
+aws --profile backblaze --endpoint-url https://s3.us-west-004.backblazeb2.com \
+  s3 sync /local/path s3://my-bucket/prefix/
+```
+
+### Rclone Configuration
+
+```ini
+# ~/.config/rclone/rclone.conf
+[backblaze]
+type = b2
+account = your-key-id
+key = your-application-key
+endpoint = s3.us-west-004.backblazeb2.com
+```
+
+```bash
+# List buckets
+rclone lsd backblaze:
+
+# Sync
+rclone sync /local/path backblaze:my-bucket/prefix/
+
+# Copy with progress
+rclone copy -P /local/path backblaze:my-bucket/
+```
+
+## Complete Production Setup
+
+See [resources/production-setup.md](resources/production-setup.md) for a complete production setup with storage buckets, backup bucket with retention, public assets bucket, and application keys.
+
+## Makefile Automation
+
+```makefile
+# B2 sync targets
+.PHONY: b2-sync-up b2-sync-down b2-backup
+
+B2_BUCKET ?= my-bucket
+B2_PREFIX ?= data/
+LOCAL_PATH ?= ./data
+
+b2-sync-up:
+	b2 sync --threads 20 $(LOCAL_PATH) b2://$(B2_BUCKET)/$(B2_PREFIX)
+
+b2-sync-down:
+	b2 sync --threads 20 b2://$(B2_BUCKET)/$(B2_PREFIX) $(LOCAL_PATH)
+
+b2-backup:
+	b2 sync --threads 20 --keep-days 30 \
+		$(LOCAL_PATH) b2://$(B2_BUCKET)/backups/$(shell date +%Y-%m-%d)/
+```
+
+## Cost Optimization
+
+- **Use lifecycle rules** - Auto-delete temp files and old versions
+- **Optimize threads** - Tune based on network/CPU (default 10, max 99)
+- **Prefer Native API** - B2 CLI is more efficient than S3-compatible for large syncs
+- **Monitor storage** - Versioned files count toward storage (old versions charged)
+- **Auto-cancel large uploads** - Enable via lifecycle to prevent "zombie" upload costs
+- **Use application keys** - Scoped keys prevent accidental operations on wrong buckets
+
+## Best Practices
+
+- **Application keys over master key** - Limit scope and capabilities
+- **Enable encryption** - Use SSE-B2 for at-rest encryption
+- **Lifecycle rules** - Auto-manage temporary and old files
+- **Versioning strategy** - Enable for backups, consider costs for large datasets
+- **S3 compatibility** - Use for existing S3 tools, prefer native API for performance
+- **Terraform state** - Store in separate bucket with file lock for compliance

--- a/plugins/majestic-devops/skills/backblaze-coder/resources/production-setup.md
+++ b/plugins/majestic-devops/skills/backblaze-coder/resources/production-setup.md
@@ -1,0 +1,140 @@
+# Complete Production Setup
+
+A complete Backblaze B2 production setup with storage, backups, public assets, and application keys.
+
+```hcl
+# variables.tf
+variable "project" {
+  description = "Project name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (prod, staging, dev)"
+  type        = string
+  default     = "prod"
+}
+
+# main.tf
+terraform {
+  required_providers {
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.8"
+    }
+  }
+}
+
+provider "b2" {}
+
+locals {
+  bucket_prefix = "${var.project}-${var.environment}"
+}
+
+# Primary storage bucket
+resource "b2_bucket" "storage" {
+  bucket_name = "${local.bucket_prefix}-storage"
+  bucket_type = "allPrivate"
+
+  bucket_info = {
+    project     = var.project
+    environment = var.environment
+    managed_by  = "opentofu"
+  }
+
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
+
+  lifecycle_rules {
+    file_name_prefix              = "temp/"
+    days_from_hiding_to_deleting  = 1
+    days_from_uploading_to_hiding = 7
+  }
+}
+
+# Backup bucket with retention
+resource "b2_bucket" "backups" {
+  bucket_name = "${local.bucket_prefix}-backups"
+  bucket_type = "allPrivate"
+
+  bucket_info = {
+    project     = var.project
+    environment = var.environment
+    purpose     = "backups"
+  }
+
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
+
+  lifecycle_rules {
+    file_name_prefix              = ""
+    days_from_hiding_to_deleting  = 90
+    days_from_uploading_to_hiding = 30
+  }
+}
+
+# Public assets bucket
+resource "b2_bucket" "assets" {
+  bucket_name = "${local.bucket_prefix}-assets"
+  bucket_type = "allPublic"
+
+  bucket_info = {
+    project = var.project
+    purpose = "public-assets"
+  }
+
+  cors_rules {
+    cors_rule_name     = "allowAll"
+    allowed_origins    = ["*"]
+    allowed_headers    = ["*"]
+    allowed_operations = ["s3_get", "s3_head"]
+    max_age_seconds    = 86400
+  }
+}
+
+# Application key for app access
+resource "b2_application_key" "app" {
+  key_name     = "${local.bucket_prefix}-app"
+  capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles", "deleteFiles"]
+  bucket_id    = b2_bucket.storage.bucket_id
+}
+
+# Read-only key for backups
+resource "b2_application_key" "backup_reader" {
+  key_name     = "${local.bucket_prefix}-backup-reader"
+  capabilities = ["listBuckets", "listFiles", "readFiles"]
+  bucket_id    = b2_bucket.backups.bucket_id
+}
+
+# outputs.tf
+output "storage_bucket_name" {
+  value = b2_bucket.storage.bucket_name
+}
+
+output "storage_bucket_id" {
+  value = b2_bucket.storage.bucket_id
+}
+
+output "assets_bucket_url" {
+  value = "https://f${substr(b2_bucket.assets.bucket_id, 0, 3)}.backblazeb2.com/file/${b2_bucket.assets.bucket_name}"
+}
+
+output "app_key_id" {
+  value = b2_application_key.app.application_key_id
+}
+
+output "app_key" {
+  value     = b2_application_key.app.application_key
+  sensitive = true
+}
+
+output "s3_endpoint" {
+  value = "s3.${data.b2_account_info.current.s3_api_url}"
+}
+
+data "b2_account_info" "current" {}
+```

--- a/plugins/majestic-devops/skills/cloud-init-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/cloud-init-coder/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: cloud-init-coder
+description: This skill guides writing cloud-init configurations for VM provisioning. Use when creating user_data blocks in Terraform/OpenTofu, or cloud-init YAML for AWS, DigitalOcean, GCP, or Azure instances.
+allowed-tools: Read, Write, Edit, Grep, Glob
+---
+
+# Cloud-Init Coder
+
+## Overview
+
+Cloud-init is the industry standard for cross-platform cloud instance initialization. It runs on first boot to configure users, packages, files, and services before the instance becomes available.
+
+## Core Format
+
+Cloud-init configs start with `#cloud-config`:
+
+```yaml
+#cloud-config
+package_update: true
+packages:
+  - nginx
+  - docker.io
+```
+
+## User Management
+
+### Create Deploy User
+
+```yaml
+#cloud-config
+users:
+  - name: deploy
+    groups: docker, sudo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA... deploy@example.com
+```
+
+### Multiple Users
+
+```yaml
+#cloud-config
+users:
+  - default  # Keep cloud provider's default user
+  - name: deploy
+    groups: docker
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA... key1
+  - name: monitoring
+    groups: adm
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA... monitoring-key
+```
+
+## Package Installation
+
+### Basic Packages
+
+```yaml
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - nginx
+  - certbot
+  - python3-certbot-nginx
+  - fail2ban
+  - ufw
+```
+
+### From Custom Repositories
+
+```yaml
+#cloud-config
+apt:
+  sources:
+    docker:
+      source: "deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable"
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+
+packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+```
+
+## SSH Hardening
+
+### Secure SSH Configuration
+
+```yaml
+#cloud-config
+runcmd:
+  # Disable root login
+  - sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i 's/^PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+
+  # Disable password authentication
+  - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+  # Increase keepalive for stable connections
+  - sed -i 's/^#\?ClientAliveInterval.*/ClientAliveInterval 60/' /etc/ssh/sshd_config
+  - sed -i 's/^#\?ClientAliveCountMax.*/ClientAliveCountMax 10/' /etc/ssh/sshd_config
+
+  # Restart SSH
+  - systemctl restart sshd
+```
+
+## Docker Setup
+
+### Docker with Compose
+
+```yaml
+#cloud-config
+package_update: true
+packages:
+  - docker.io
+  - docker-compose-plugin
+
+groups:
+  - docker
+
+users:
+  - name: deploy
+    groups: docker
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA...
+
+runcmd:
+  - systemctl enable --now docker
+  - usermod -aG docker deploy
+```
+
+### Docker with Custom Daemon Config
+
+```yaml
+#cloud-config
+write_files:
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "log-driver": "json-file",
+        "log-opts": {
+          "max-size": "10m",
+          "max-file": "3"
+        },
+        "storage-driver": "overlay2"
+      }
+
+runcmd:
+  - systemctl enable --now docker
+```
+
+## File Creation
+
+### Write Configuration Files
+
+```yaml
+#cloud-config
+write_files:
+  - path: /etc/nginx/sites-available/app
+    content: |
+      server {
+          listen 80;
+          server_name example.com;
+          location / {
+              proxy_pass http://127.0.0.1:3000;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+          }
+      }
+    owner: root:root
+    permissions: '0644'
+
+  - path: /opt/app/.env
+    content: |
+      RAILS_ENV=production
+      PORT=3000
+    owner: deploy:deploy
+    permissions: '0600'
+```
+
+### Download Files
+
+```yaml
+#cloud-config
+runcmd:
+  - curl -fsSL https://example.com/setup.sh -o /opt/setup.sh
+  - chmod +x /opt/setup.sh
+  - /opt/setup.sh
+```
+
+## Service Configuration
+
+### Enable and Start Services
+
+```yaml
+#cloud-config
+runcmd:
+  - systemctl enable --now docker
+  - systemctl enable --now nginx
+  - systemctl enable --now fail2ban
+```
+
+### Systemd Service Creation
+
+```yaml
+#cloud-config
+write_files:
+  - path: /etc/systemd/system/myapp.service
+    content: |
+      [Unit]
+      Description=My Application
+      After=network.target docker.service
+      Requires=docker.service
+
+      [Service]
+      Type=simple
+      User=deploy
+      WorkingDirectory=/opt/app
+      ExecStart=/usr/bin/docker compose up
+      ExecStop=/usr/bin/docker compose down
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable --now myapp
+```
+
+## Firewall Configuration
+
+### UFW Setup
+
+```yaml
+#cloud-config
+packages:
+  - ufw
+
+runcmd:
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow ssh
+  - ufw allow http
+  - ufw allow https
+  - ufw --force enable
+```
+
+## Terraform/OpenTofu Integration
+
+### Inline User Data
+
+```hcl
+resource "digitalocean_droplet" "app" {
+  name   = "app-server"
+  image  = "ubuntu-22-04-x64"
+  size   = "s-1vcpu-1gb"
+  region = "nyc1"
+
+  user_data = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - docker.io
+      - docker-compose-plugin
+    users:
+      - name: deploy
+        groups: docker
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh_authorized_keys:
+          - ${var.deploy_ssh_key}
+    runcmd:
+      - systemctl enable --now docker
+  EOT
+}
+```
+
+### Template File
+
+```hcl
+# templates/cloud-init.yaml
+#cloud-config
+package_update: true
+packages:
+  - docker.io
+users:
+  - name: ${username}
+    groups: docker
+    ssh_authorized_keys:
+      - ${ssh_key}
+
+# main.tf
+resource "digitalocean_droplet" "app" {
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml", {
+    username = var.deploy_user
+    ssh_key  = var.deploy_ssh_key
+  })
+}
+```
+
+## Complete Production Example
+
+```yaml
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - fail2ban
+  - ufw
+  - unattended-upgrades
+
+groups:
+  - docker
+
+users:
+  - name: deploy
+    groups: docker, sudo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA... deploy-key
+
+write_files:
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "log-driver": "json-file",
+        "log-opts": { "max-size": "10m", "max-file": "3" }
+      }
+
+  - path: /etc/fail2ban/jail.local
+    content: |
+      [sshd]
+      enabled = true
+      port = ssh
+      filter = sshd
+      maxretry = 3
+      bantime = 3600
+
+runcmd:
+  # Docker
+  - systemctl enable --now docker
+
+  # SSH hardening
+  - sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - sed -i 's/^#\?ClientAliveInterval.*/ClientAliveInterval 60/' /etc/ssh/sshd_config
+  - sed -i 's/^#\?ClientAliveCountMax.*/ClientAliveCountMax 10/' /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+  # Firewall
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow ssh
+  - ufw allow http
+  - ufw allow https
+  - ufw --force enable
+
+  # Fail2ban
+  - systemctl enable --now fail2ban
+
+  # Auto-updates
+  - systemctl enable --now unattended-upgrades
+
+final_message: "Cloud-init completed after $UPTIME seconds"
+```
+
+## Debugging
+
+### Check Cloud-Init Status
+
+```bash
+# View cloud-init status
+cloud-init status
+
+# View cloud-init logs
+cat /var/log/cloud-init.log
+cat /var/log/cloud-init-output.log
+
+# Re-run cloud-init (for testing)
+sudo cloud-init clean
+sudo cloud-init init
+```
+
+### Common Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| YAML parse error | Indentation wrong | Use 2-space indent, validate YAML |
+| User not created | Missing `users:` key | Ensure `users:` is at root level |
+| Packages not installed | `package_update: false` | Set `package_update: true` |
+| SSH key rejected | Wrong key format | Use full public key string |
+| Service not starting | Order dependency | Use `After=` in systemd unit |

--- a/plugins/majestic-devops/skills/cloudflare-coder/resources/load-balancer.md
+++ b/plugins/majestic-devops/skills/cloudflare-coder/resources/load-balancer.md
@@ -1,0 +1,78 @@
+# Argo & Load Balancing
+
+## Argo Smart Routing
+
+```hcl
+resource "cloudflare_argo" "main" {
+  zone_id        = data.cloudflare_zone.main.id
+  tiered_caching = "on"
+  smart_routing  = "on"
+}
+```
+
+## Load Balancer
+
+```hcl
+# Origin pools
+resource "cloudflare_load_balancer_pool" "primary" {
+  account_id = var.cloudflare_account_id
+  name       = "primary-pool"
+
+  origins {
+    name    = "primary-origin"
+    address = var.primary_server_ip
+    enabled = true
+    weight  = 1
+  }
+
+  minimum_origins = 1
+  monitor         = cloudflare_load_balancer_monitor.http.id
+
+  origin_steering {
+    policy = "random"
+  }
+}
+
+resource "cloudflare_load_balancer_pool" "fallback" {
+  account_id = var.cloudflare_account_id
+  name       = "fallback-pool"
+
+  origins {
+    name    = "fallback-origin"
+    address = var.fallback_server_ip
+    enabled = true
+  }
+
+  minimum_origins = 1
+  monitor         = cloudflare_load_balancer_monitor.http.id
+}
+
+# Health check monitor
+resource "cloudflare_load_balancer_monitor" "http" {
+  account_id     = var.cloudflare_account_id
+  type           = "http"
+  expected_codes = "200"
+  method         = "GET"
+  path           = "/health"
+  interval       = 60
+  retries        = 2
+  timeout        = 5
+  description    = "HTTP health check"
+}
+
+# Load balancer
+resource "cloudflare_load_balancer" "main" {
+  zone_id          = data.cloudflare_zone.main.id
+  name             = "lb.example.com"
+  default_pool_ids = [cloudflare_load_balancer_pool.primary.id]
+  fallback_pool_id = cloudflare_load_balancer_pool.fallback.id
+  proxied          = true
+
+  session_affinity = "cookie"
+  session_affinity_ttl = 1800
+
+  adaptive_routing {
+    failover_across_pools = true
+  }
+}
+```

--- a/plugins/majestic-devops/skills/cloudflare-coder/resources/production-zone.md
+++ b/plugins/majestic-devops/skills/cloudflare-coder/resources/production-zone.md
@@ -1,0 +1,203 @@
+# Complete Production Zone Example
+
+A complete Terraform configuration for a production-ready Cloudflare zone with DNS, SSL/TLS, WAF, caching, and redirects.
+
+```hcl
+locals {
+  domain = var.domain
+}
+
+# Zone data
+data "cloudflare_zone" "main" {
+  name = local.domain
+}
+
+# DNS Records
+resource "cloudflare_record" "root" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "@"
+  type    = "A"
+  content = var.server_ip
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_record" "www" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "www"
+  type    = "CNAME"
+  content = "@"
+  ttl     = 1
+  proxied = true
+}
+
+# SSL/TLS - Strict mode
+resource "cloudflare_zone_settings_override" "ssl" {
+  zone_id = data.cloudflare_zone.main.id
+
+  settings {
+    ssl                      = "strict"
+    min_tls_version          = "1.2"
+    tls_1_3                  = "on"
+    always_use_https         = "on"
+    automatic_https_rewrites = "on"
+
+    security_header {
+      enabled            = true
+      max_age            = 31536000
+      include_subdomains = true
+      preload            = true
+      nosniff            = true
+    }
+  }
+}
+
+# Performance settings
+resource "cloudflare_zone_settings_override" "performance" {
+  zone_id = data.cloudflare_zone.main.id
+
+  settings {
+    brotli       = "on"
+    early_hints  = "on"
+    http2        = "on"
+    http3        = "on"
+    zero_rtt     = "on"
+
+    minify {
+      css  = "on"
+      html = "on"
+      js   = "on"
+    }
+  }
+}
+
+# Security settings
+resource "cloudflare_zone_settings_override" "security" {
+  zone_id = data.cloudflare_zone.main.id
+
+  settings {
+    security_level      = "medium"
+    challenge_ttl       = 1800
+    browser_check       = "on"
+    email_obfuscation   = "on"
+    hotlink_protection  = "on"
+  }
+}
+
+# WAF - Managed rulesets
+resource "cloudflare_ruleset" "waf" {
+  zone_id     = data.cloudflare_zone.main.id
+  name        = "Managed WAF"
+  description = "Cloudflare managed security rules"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+
+  rules {
+    action = "execute"
+    action_parameters {
+      id = "efb7b8c949ac4650a09736fc376e9aee"
+    }
+    expression  = "true"
+    description = "Cloudflare Managed Ruleset"
+    enabled     = true
+  }
+}
+
+# Cache rules
+resource "cloudflare_ruleset" "cache" {
+  zone_id     = data.cloudflare_zone.main.id
+  name        = "Cache Configuration"
+  description = "Caching rules"
+  kind        = "zone"
+  phase       = "http_request_cache_settings"
+
+  rules {
+    action = "set_cache_settings"
+    action_parameters {
+      cache = true
+      edge_ttl {
+        mode    = "override_origin"
+        default = 2592000
+      }
+    }
+    expression  = "(http.request.uri.path.extension in {\"css\" \"js\" \"jpg\" \"jpeg\" \"png\" \"gif\" \"svg\" \"woff\" \"woff2\" \"ico\"})"
+    description = "Cache static assets"
+    enabled     = true
+  }
+
+  rules {
+    action = "set_cache_settings"
+    action_parameters {
+      cache = false
+    }
+    expression  = "(starts_with(http.request.uri.path, \"/api/\") or starts_with(http.request.uri.path, \"/admin\"))"
+    description = "Bypass cache for dynamic paths"
+    enabled     = true
+  }
+}
+
+# Redirect www to apex
+resource "cloudflare_ruleset" "redirects" {
+  zone_id     = data.cloudflare_zone.main.id
+  name        = "Redirects"
+  description = "URL redirects"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+
+  rules {
+    action = "redirect"
+    action_parameters {
+      from_value {
+        status_code = 301
+        target_url {
+          expression = "concat(\"https://${local.domain}\", http.request.uri.path)"
+        }
+        preserve_query_string = true
+      }
+    }
+    expression  = "(http.host eq \"www.${local.domain}\")"
+    description = "Redirect www to apex"
+    enabled     = true
+  }
+}
+
+# Outputs
+output "zone_id" {
+  value = data.cloudflare_zone.main.id
+}
+
+output "nameservers" {
+  value = data.cloudflare_zone.main.name_servers
+}
+```
+
+## Variables Template
+
+```hcl
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "domain" {
+  description = "Domain name"
+  type        = string
+}
+
+variable "server_ip" {
+  description = "Origin server IP"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (prod, staging, dev)"
+  type        = string
+  default     = "prod"
+}
+
+variable "ssh_allowed_ips" {
+  description = "IPs allowed for SSH access"
+  type        = list(string)
+  default     = []
+}
+```

--- a/plugins/majestic-devops/skills/cloudflare-coder/resources/waf.md
+++ b/plugins/majestic-devops/skills/cloudflare-coder/resources/waf.md
@@ -1,0 +1,117 @@
+# Firewall & WAF
+
+## IP Access Rules
+
+```hcl
+# Block specific IP
+resource "cloudflare_access_rule" "block_bad_actor" {
+  zone_id = data.cloudflare_zone.main.id
+  mode    = "block"
+  notes   = "Blocked for abuse"
+
+  configuration {
+    target = "ip"
+    value  = "1.2.3.4"
+  }
+}
+
+# Allow office IP range
+resource "cloudflare_access_rule" "allow_office" {
+  zone_id = data.cloudflare_zone.main.id
+  mode    = "whitelist"
+  notes   = "Office network"
+
+  configuration {
+    target = "ip_range"
+    value  = "203.0.113.0/24"
+  }
+}
+
+# Block country
+resource "cloudflare_access_rule" "block_country" {
+  zone_id = data.cloudflare_zone.main.id
+  mode    = "block"
+  notes   = "High-risk country"
+
+  configuration {
+    target = "country"
+    value  = "XX"
+  }
+}
+```
+
+## WAF Custom Rules (Rulesets)
+
+```hcl
+resource "cloudflare_ruleset" "waf_custom" {
+  zone_id     = data.cloudflare_zone.main.id
+  name        = "Custom WAF Rules"
+  description = "Application-specific WAF rules"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  # Block requests to admin without auth header
+  rules {
+    action      = "block"
+    expression  = "(starts_with(http.request.uri.path, \"/admin\") and not http.request.headers[\"x-admin-key\"][0] eq \"${var.admin_key}\")"
+    description = "Block unauthorized admin access"
+    enabled     = true
+  }
+
+  # Challenge suspicious login attempts
+  rules {
+    action      = "managed_challenge"
+    expression  = "(http.request.uri.path eq \"/login\" and http.request.method eq \"POST\" and ip.geoip.country ne \"US\")"
+    description = "Challenge non-US login attempts"
+    enabled     = true
+  }
+
+  # Rate limit API
+  rules {
+    action = "block"
+    ratelimit {
+      characteristics     = ["ip.src"]
+      period              = 60
+      requests_per_period = 100
+      mitigation_timeout  = 600
+    }
+    expression  = "(starts_with(http.request.uri.path, \"/api/\"))"
+    description = "Rate limit API to 100 req/min per IP"
+    enabled     = true
+  }
+}
+```
+
+## Managed WAF Rulesets
+
+```hcl
+resource "cloudflare_ruleset" "waf_managed" {
+  zone_id     = data.cloudflare_zone.main.id
+  name        = "Managed WAF"
+  description = "Deploy Cloudflare managed rulesets"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+
+  # Cloudflare Managed Ruleset
+  rules {
+    action = "execute"
+    action_parameters {
+      id = "efb7b8c949ac4650a09736fc376e9aee"  # Cloudflare Managed Ruleset
+    }
+    expression  = "true"
+    description = "Execute Cloudflare Managed Ruleset"
+    enabled     = true
+  }
+
+  # OWASP Core Ruleset
+  rules {
+    action = "execute"
+    action_parameters {
+      id = "4814384a9e5d4991b9815dcfc25d2f1f"  # OWASP Core Ruleset
+    }
+    expression  = "true"
+    description = "Execute OWASP Core Ruleset"
+    enabled     = true
+  }
+}
+```

--- a/plugins/majestic-devops/skills/digitalocean-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/digitalocean-coder/SKILL.md
@@ -1,0 +1,461 @@
+---
+name: digitalocean-coder
+description: This skill guides writing DigitalOcean infrastructure with OpenTofu/Terraform. Use when provisioning Droplets, VPCs, Managed Databases, Firewalls, or other DO resources.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# DigitalOcean Coder
+
+## Overview
+
+DigitalOcean provides simple, developer-friendly cloud infrastructure. This skill covers OpenTofu/Terraform patterns for DO resources.
+
+## Provider Setup
+
+```hcl
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  # Token from environment: DIGITALOCEAN_TOKEN
+}
+```
+
+## VPC (Virtual Private Cloud)
+
+```hcl
+resource "digitalocean_vpc" "main" {
+  name     = "${var.project}-${var.environment}-vpc"
+  region   = var.region
+  ip_range = "10.10.0.0/16"
+
+  description = "VPC for ${var.project} ${var.environment}"
+}
+```
+
+## Droplets (Compute)
+
+### Basic Droplet
+
+```hcl
+resource "digitalocean_droplet" "app" {
+  name     = "${var.project}-${var.environment}-app"
+  region   = var.region
+  size     = var.droplet_size  # s-1vcpu-1gb, s-2vcpu-4gb, etc.
+  image    = "ubuntu-22-04-x64"
+  vpc_uuid = digitalocean_vpc.main.id
+
+  ssh_keys   = var.ssh_key_ids
+  monitoring = true
+  ipv6       = false
+
+  tags = [var.project, var.environment]
+}
+```
+
+### Droplet with Cloud-Init
+
+```hcl
+resource "digitalocean_droplet" "app" {
+  name     = "${var.project}-app"
+  region   = var.region
+  size     = "s-1vcpu-2gb"
+  image    = "ubuntu-22-04-x64"
+  vpc_uuid = digitalocean_vpc.main.id
+
+  ssh_keys   = var.ssh_key_ids
+  monitoring = true
+
+  user_data = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - docker.io
+      - docker-compose-plugin
+    users:
+      - name: deploy
+        groups: docker
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh_authorized_keys:
+          - ${var.deploy_ssh_key}
+    runcmd:
+      - systemctl enable --now docker
+      - sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+  EOT
+
+  tags = [var.project]
+}
+```
+
+### Common Droplet Sizes
+
+| Size | vCPUs | Memory | Use Case |
+|------|-------|--------|----------|
+| `s-1vcpu-1gb` | 1 | 1 GB | Testing, small apps |
+| `s-1vcpu-2gb` | 1 | 2 GB | Small production |
+| `s-2vcpu-4gb` | 2 | 4 GB | Medium apps |
+| `s-4vcpu-8gb` | 4 | 8 GB | Production workloads |
+| `c-2` | 2 | 4 GB | CPU-intensive |
+| `m-2vcpu-16gb` | 2 | 16 GB | Memory-intensive |
+
+## Reserved IP (Static IP)
+
+```hcl
+resource "digitalocean_reserved_ip" "app" {
+  region = var.region
+}
+
+resource "digitalocean_reserved_ip_assignment" "app" {
+  ip_address = digitalocean_reserved_ip.app.ip_address
+  droplet_id = digitalocean_droplet.app.id
+}
+
+output "app_ip" {
+  value = digitalocean_reserved_ip.app.ip_address
+}
+```
+
+## Firewall
+
+### Basic Web Server Firewall
+
+```hcl
+resource "digitalocean_firewall" "web" {
+  name = "${var.project}-web-firewall"
+
+  droplet_ids = [digitalocean_droplet.app.id]
+
+  # Inbound rules
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = var.ssh_allowed_ips  # Restrict SSH access
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Outbound rules
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+```
+
+### Dynamic IP Whitelist
+
+```hcl
+variable "db_allowed_ips" {
+  type        = list(string)
+  default     = []
+  description = "IPs allowed to access database directly"
+}
+
+resource "digitalocean_database_firewall" "postgres" {
+  cluster_id = digitalocean_database_cluster.postgres.id
+
+  # Always allow app droplet
+  rule {
+    type  = "droplet"
+    value = digitalocean_droplet.app.id
+  }
+
+  # Dynamic IP whitelist for developers
+  dynamic "rule" {
+    for_each = var.db_allowed_ips
+    content {
+      type  = "ip_addr"
+      value = rule.value
+    }
+  }
+}
+```
+
+## Managed Database
+
+### PostgreSQL Cluster
+
+```hcl
+resource "digitalocean_database_cluster" "postgres" {
+  name       = "${var.project}-${var.environment}-pg"
+  engine     = "pg"
+  version    = "16"
+  size       = var.db_size  # db-s-1vcpu-1gb, db-s-2vcpu-4gb
+  region     = var.region
+  node_count = 1  # Increase for HA
+
+  # CRITICAL: Use private network
+  private_network_uuid = digitalocean_vpc.main.id
+
+  tags = [var.project, var.environment]
+}
+
+# Database firewall - restrict access
+resource "digitalocean_database_firewall" "postgres" {
+  cluster_id = digitalocean_database_cluster.postgres.id
+
+  rule {
+    type  = "droplet"
+    value = digitalocean_droplet.app.id
+  }
+}
+
+output "database_uri" {
+  value     = digitalocean_database_cluster.postgres.uri
+  sensitive = true
+}
+
+output "database_private_uri" {
+  value     = digitalocean_database_cluster.postgres.private_uri
+  sensitive = true
+}
+```
+
+### Database Sizes
+
+| Size | vCPUs | Memory | Storage | Use Case |
+|------|-------|--------|---------|----------|
+| `db-s-1vcpu-1gb` | 1 | 1 GB | 10 GB | Development |
+| `db-s-1vcpu-2gb` | 1 | 2 GB | 25 GB | Small production |
+| `db-s-2vcpu-4gb` | 2 | 4 GB | 38 GB | Production |
+| `db-s-4vcpu-8gb` | 4 | 8 GB | 115 GB | High traffic |
+
+### Redis Cluster
+
+```hcl
+resource "digitalocean_database_cluster" "redis" {
+  name       = "${var.project}-${var.environment}-redis"
+  engine     = "redis"
+  version    = "7"
+  size       = "db-s-1vcpu-1gb"
+  region     = var.region
+  node_count = 1
+
+  private_network_uuid = digitalocean_vpc.main.id
+  tags                 = [var.project]
+}
+```
+
+## Spaces (Object Storage)
+
+```hcl
+resource "digitalocean_spaces_bucket" "assets" {
+  name   = "${var.project}-assets"
+  region = var.spaces_region  # nyc3, sfo3, ams3, sgp1, fra1
+
+  acl = "private"  # or "public-read"
+}
+
+resource "digitalocean_spaces_bucket_cors_configuration" "assets" {
+  bucket = digitalocean_spaces_bucket.assets.id
+  region = var.spaces_region
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST"]
+    allowed_origins = ["https://${var.domain}"]
+    max_age_seconds = 3600
+  }
+}
+
+output "spaces_endpoint" {
+  value = digitalocean_spaces_bucket.assets.bucket_domain_name
+}
+```
+
+## DNS Records
+
+```hcl
+resource "digitalocean_domain" "main" {
+  name = var.domain
+}
+
+resource "digitalocean_record" "app" {
+  domain = digitalocean_domain.main.id
+  type   = "A"
+  name   = "@"
+  value  = digitalocean_reserved_ip.app.ip_address
+  ttl    = 300
+}
+
+resource "digitalocean_record" "www" {
+  domain = digitalocean_domain.main.id
+  type   = "CNAME"
+  name   = "www"
+  value  = "@"
+  ttl    = 300
+}
+```
+
+## SSH Keys
+
+```hcl
+# Reference existing key
+data "digitalocean_ssh_key" "deploy" {
+  name = "deploy-key"
+}
+
+# Or create new key
+resource "digitalocean_ssh_key" "deploy" {
+  name       = "${var.project}-deploy"
+  public_key = file("~/.ssh/deploy.pub")
+}
+```
+
+## Complete Production Stack
+
+```hcl
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+}
+
+# VPC
+resource "digitalocean_vpc" "main" {
+  name     = "${local.name_prefix}-vpc"
+  region   = var.region
+  ip_range = "10.10.0.0/16"
+}
+
+# App Server
+resource "digitalocean_droplet" "app" {
+  name     = "${local.name_prefix}-app"
+  region   = var.region
+  size     = var.droplet_size
+  image    = "ubuntu-22-04-x64"
+  vpc_uuid = digitalocean_vpc.main.id
+
+  ssh_keys   = [data.digitalocean_ssh_key.deploy.id]
+  monitoring = true
+
+  user_data = file("${path.module}/cloud-init.yaml")
+  tags      = [var.project, var.environment]
+}
+
+# Static IP
+resource "digitalocean_reserved_ip" "app" {
+  region = var.region
+}
+
+resource "digitalocean_reserved_ip_assignment" "app" {
+  ip_address = digitalocean_reserved_ip.app.ip_address
+  droplet_id = digitalocean_droplet.app.id
+}
+
+# Firewall
+resource "digitalocean_firewall" "app" {
+  name        = "${local.name_prefix}-firewall"
+  droplet_ids = [digitalocean_droplet.app.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = var.ssh_allowed_ips
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# Database
+resource "digitalocean_database_cluster" "postgres" {
+  name                 = "${local.name_prefix}-pg"
+  engine               = "pg"
+  version              = "16"
+  size                 = var.db_size
+  region               = var.region
+  node_count           = 1
+  private_network_uuid = digitalocean_vpc.main.id
+  tags                 = [var.project]
+}
+
+resource "digitalocean_database_firewall" "postgres" {
+  cluster_id = digitalocean_database_cluster.postgres.id
+
+  rule {
+    type  = "droplet"
+    value = digitalocean_droplet.app.id
+  }
+}
+
+# Outputs
+output "app_ip" {
+  value = digitalocean_reserved_ip.app.ip_address
+}
+
+output "database_uri" {
+  value     = digitalocean_database_cluster.postgres.private_uri
+  sensitive = true
+}
+```
+
+## Best Practices
+
+### Security
+- Always use VPC for private networking
+- Restrict database to droplet access only
+- Use reserved IPs for consistent addressing
+- Limit SSH to specific IPs via firewall
+- Use cloud-init to disable root login
+
+### Cost Optimization
+- Use appropriate droplet sizes
+- Single-node databases for non-critical workloads
+- Reserved IPs are free when assigned
+- Monitor with built-in metrics
+
+### Networking
+- Use `private_uri` for database connections
+- Place all resources in same VPC
+- Use firewall rules, not iptables
+- Enable monitoring on droplets

--- a/plugins/majestic-devops/skills/hetzner-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/hetzner-coder/SKILL.md
@@ -1,0 +1,557 @@
+---
+name: hetzner-coder
+description: This skill guides provisioning Hetzner Cloud infrastructure with OpenTofu/Terraform. Use when creating servers, networks, firewalls, load balancers, or volumes on Hetzner Cloud.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# Hetzner Coder
+
+## Overview
+
+Hetzner Cloud offers high-performance, cost-effective cloud infrastructure with European data centers. This skill covers OpenTofu/Terraform patterns for Hetzner resources.
+
+## Provider Setup
+
+```hcl
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.50"
+    }
+  }
+}
+
+provider "hcloud" {
+  # Token from environment: HCLOUD_TOKEN
+  # Or explicitly (not recommended):
+  # token = var.hcloud_token
+}
+```
+
+### Authentication
+
+```bash
+# Set token via environment variable
+export HCLOUD_TOKEN="your-api-token"
+
+# Or with 1Password
+HCLOUD_TOKEN=op://Infrastructure/Hetzner/api_token
+```
+
+**Token Permissions:**
+- **Read** - GET requests only (monitoring, auditing)
+- **Read & Write** - Full access (required for Terraform)
+
+## Locations and Datacenters
+
+| Location | Code | Region | Network Zone |
+|----------|------|--------|--------------|
+| Falkenstein | `fsn1` | Germany | `eu-central` |
+| Nuremberg | `nbg1` | Germany | `eu-central` |
+| Helsinki | `hel1` | Finland | `eu-central` |
+| Ashburn | `ash` | US East | `us-east` |
+| Hillsboro | `hil` | US West | `us-west` |
+
+## Server Types
+
+### Shared CPU (Best for general workloads)
+
+| Type | vCPUs | RAM | Storage | Best For |
+|------|-------|-----|---------|----------|
+| `cx22` | 2 | 4 GB | 40 GB | Small apps |
+| `cx32` | 4 | 8 GB | 80 GB | Medium apps |
+| `cx42` | 8 | 16 GB | 160 GB | Production |
+| `cx52` | 16 | 32 GB | 320 GB | High traffic |
+
+### AMD EPYC (CPX - Better single-thread)
+
+| Type | vCPUs | RAM | Storage |
+|------|-------|-----|---------|
+| `cpx11` | 2 | 2 GB | 40 GB |
+| `cpx21` | 3 | 4 GB | 80 GB |
+| `cpx31` | 4 | 8 GB | 160 GB |
+| `cpx41` | 8 | 16 GB | 240 GB |
+| `cpx51` | 16 | 32 GB | 360 GB |
+
+### ARM64 (CAX - Best price/performance)
+
+| Type | vCPUs | RAM | Storage |
+|------|-------|-----|---------|
+| `cax11` | 2 | 4 GB | 40 GB |
+| `cax21` | 4 | 8 GB | 80 GB |
+| `cax31` | 8 | 16 GB | 160 GB |
+| `cax41` | 16 | 32 GB | 320 GB |
+
+### Dedicated vCPU (CCX - Guaranteed resources)
+
+| Type | vCPUs | RAM | Storage |
+|------|-------|-----|---------|
+| `ccx13` | 2 | 8 GB | 80 GB |
+| `ccx23` | 4 | 16 GB | 160 GB |
+| `ccx33` | 8 | 32 GB | 240 GB |
+| `ccx43` | 16 | 64 GB | 360 GB |
+
+## Servers (Compute)
+
+### Basic Server
+
+```hcl
+resource "hcloud_server" "app" {
+  name        = "${var.project}-${var.environment}-app"
+  server_type = "cx22"
+  image       = "ubuntu-24.04"
+  location    = "fsn1"
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+
+  labels = {
+    environment = var.environment
+    project     = var.project
+    role        = "app"
+  }
+
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = true
+  }
+}
+```
+
+### Server with Cloud-Init
+
+```hcl
+resource "hcloud_server" "app" {
+  name        = "${var.project}-app"
+  server_type = "cx22"
+  image       = "ubuntu-24.04"
+  location    = "fsn1"
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+
+  user_data = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - docker.io
+      - docker-compose-plugin
+
+    users:
+      - name: deploy
+        groups: docker, sudo
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh_authorized_keys:
+          - ${var.deploy_ssh_key}
+
+    runcmd:
+      - systemctl enable --now docker
+      - sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+      - sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+  EOT
+
+  labels = {
+    environment = var.environment
+    role        = "app"
+  }
+}
+```
+
+### ARM64 Server (Cost-Effective)
+
+```hcl
+resource "hcloud_server" "worker" {
+  name        = "${var.project}-worker"
+  server_type = "cax21"  # ARM64 - great price/performance
+  image       = "ubuntu-24.04"
+  location    = "fsn1"
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+
+  labels = {
+    role = "worker"
+    arch = "arm64"
+  }
+}
+```
+
+## Private Networks
+
+### Network with Subnet
+
+```hcl
+resource "hcloud_network" "private" {
+  name     = "${var.project}-network"
+  ip_range = "10.0.0.0/16"
+
+  labels = {
+    project = var.project
+  }
+}
+
+resource "hcloud_network_subnet" "private" {
+  network_id   = hcloud_network.private.id
+  type         = "cloud"
+  network_zone = "eu-central"  # Must match server location zone
+  ip_range     = "10.0.1.0/24"
+}
+```
+
+### Server in Private Network
+
+```hcl
+resource "hcloud_server" "db" {
+  name        = "${var.project}-db"
+  server_type = "cpx31"
+  image       = "ubuntu-24.04"
+  location    = "fsn1"
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+
+  # Attach to private network
+  network {
+    network_id = hcloud_network.private.id
+    ip         = "10.0.1.10"  # Optional: specific IP
+  }
+
+  # Optionally disable public IP for security
+  public_net {
+    ipv4_enabled = false
+    ipv6_enabled = false
+  }
+
+  labels = {
+    role = "database"
+  }
+
+  depends_on = [hcloud_network_subnet.private]
+}
+```
+
+## Firewalls
+
+### Web Server Firewall
+
+```hcl
+resource "hcloud_firewall" "web" {
+  name = "${var.project}-web-firewall"
+
+  # SSH from specific IPs only
+  rule {
+    description = "SSH"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = var.ssh_allowed_ips
+  }
+
+  # HTTP/HTTPS from anywhere
+  rule {
+    description = "HTTP"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "80"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    description = "HTTPS"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "443"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Apply to servers with label
+  apply_to {
+    label_selector = "role=web"
+  }
+}
+```
+
+### Database Firewall (Private Only)
+
+```hcl
+resource "hcloud_firewall" "db" {
+  name = "${var.project}-db-firewall"
+
+  # PostgreSQL from private network only
+  rule {
+    description = "PostgreSQL"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "5432"
+    source_ips  = ["10.0.0.0/16"]  # Private network range
+  }
+
+  # SSH from bastion only
+  rule {
+    description = "SSH from bastion"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = ["10.0.1.1/32"]  # Bastion IP
+  }
+
+  apply_to {
+    label_selector = "role=database"
+  }
+}
+```
+
+## Floating IPs (High Availability)
+
+```hcl
+resource "hcloud_floating_ip" "app" {
+  type          = "ipv4"
+  name          = "${var.project}-vip"
+  home_location = "fsn1"
+
+  labels = {
+    project = var.project
+    purpose = "failover"
+  }
+}
+
+resource "hcloud_floating_ip_assignment" "app" {
+  floating_ip_id = hcloud_floating_ip.app.id
+  server_id      = hcloud_server.app.id
+}
+
+output "floating_ip" {
+  value = hcloud_floating_ip.app.ip_address
+}
+```
+
+## Load Balancers
+
+### HTTP Load Balancer
+
+```hcl
+resource "hcloud_load_balancer" "web" {
+  name               = "${var.project}-lb"
+  load_balancer_type = "lb11"
+  location           = "fsn1"
+
+  labels = {
+    project = var.project
+  }
+}
+
+resource "hcloud_load_balancer_network" "web" {
+  load_balancer_id = hcloud_load_balancer.web.id
+  network_id       = hcloud_network.private.id
+  ip               = "10.0.1.100"
+}
+
+resource "hcloud_load_balancer_service" "http" {
+  load_balancer_id = hcloud_load_balancer.web.id
+  protocol         = "http"
+  listen_port      = 80
+  destination_port = 8080
+
+  health_check {
+    protocol = "http"
+    port     = 8080
+    interval = 10
+    timeout  = 5
+    retries  = 3
+
+    http {
+      path         = "/health"
+      status_codes = ["200"]
+    }
+  }
+}
+
+resource "hcloud_load_balancer_target" "web" {
+  load_balancer_id = hcloud_load_balancer.web.id
+  type             = "server"
+  server_id        = hcloud_server.app.id
+  use_private_ip   = true
+
+  depends_on = [hcloud_load_balancer_network.web]
+}
+```
+
+### HTTPS Load Balancer with Certificate
+
+```hcl
+resource "hcloud_managed_certificate" "web" {
+  name         = "${var.project}-cert"
+  domain_names = [var.domain, "www.${var.domain}"]
+
+  labels = {
+    project = var.project
+  }
+}
+
+resource "hcloud_load_balancer_service" "https" {
+  load_balancer_id = hcloud_load_balancer.web.id
+  protocol         = "https"
+  listen_port      = 443
+  destination_port = 8080
+
+  http {
+    certificates = [hcloud_managed_certificate.web.id]
+    redirect_http = true
+  }
+
+  health_check {
+    protocol = "http"
+    port     = 8080
+    interval = 10
+    timeout  = 5
+  }
+}
+```
+
+## Volumes (Persistent Storage)
+
+```hcl
+resource "hcloud_volume" "data" {
+  name      = "${var.project}-data"
+  size      = 100  # GB
+  location  = "fsn1"
+  format    = "ext4"
+
+  labels = {
+    project = var.project
+    purpose = "database"
+  }
+}
+
+resource "hcloud_volume_attachment" "data" {
+  volume_id = hcloud_volume.data.id
+  server_id = hcloud_server.db.id
+  automount = true
+}
+```
+
+## SSH Keys
+
+```hcl
+resource "hcloud_ssh_key" "deploy" {
+  name       = "${var.project}-deploy"
+  public_key = file(var.ssh_public_key_path)
+
+  labels = {
+    project = var.project
+    purpose = "deployment"
+  }
+}
+```
+
+## Placement Groups (High Availability)
+
+```hcl
+resource "hcloud_placement_group" "spread" {
+  name = "${var.project}-spread"
+  type = "spread"  # Distribute across physical hosts
+
+  labels = {
+    project = var.project
+  }
+}
+
+resource "hcloud_server" "app" {
+  count = 3
+
+  name              = "${var.project}-app-${count.index}"
+  server_type       = "cx22"
+  image             = "ubuntu-24.04"
+  location          = "fsn1"
+  placement_group_id = hcloud_placement_group.spread.id
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+
+  labels = {
+    project = var.project
+    role    = "app"
+    index   = count.index
+  }
+}
+```
+
+## Snapshots and Backups
+
+### Enable Automatic Backups
+
+```hcl
+resource "hcloud_server" "app" {
+  name        = "${var.project}-app"
+  server_type = "cx22"
+  image       = "ubuntu-24.04"
+  location    = "fsn1"
+
+  backups = true  # Enable automatic backups (20% surcharge)
+
+  ssh_keys = [hcloud_ssh_key.deploy.id]
+}
+```
+
+### Manual Snapshot
+
+```hcl
+resource "hcloud_snapshot" "before_upgrade" {
+  server_id   = hcloud_server.app.id
+  description = "Snapshot before major upgrade"
+
+  labels = {
+    project = var.project
+    purpose = "pre-upgrade"
+  }
+}
+```
+
+## Labels Best Practices
+
+Use consistent labels for organization and filtering:
+
+```hcl
+locals {
+  common_labels = {
+    project     = var.project
+    environment = var.environment
+    managed_by  = "opentofu"
+  }
+}
+
+resource "hcloud_server" "app" {
+  # ...
+  labels = merge(local.common_labels, {
+    role      = "app"
+    component = "api"
+  })
+}
+
+resource "hcloud_network" "private" {
+  # ...
+  labels = local.common_labels
+}
+```
+
+**Recommended label schema:**
+
+| Key | Values | Purpose |
+|-----|--------|---------|
+| `environment` | `prod`, `staging`, `dev` | Environment separation |
+| `project` | Your project name | Project grouping |
+| `role` | `web`, `api`, `db`, `worker` | Server role |
+| `team` | Team name | Cost allocation |
+| `managed_by` | `opentofu`, `terraform` | IaC tracking |
+
+## Complete Production Stack
+
+See [resources/production-stack.md](resources/production-stack.md) for a complete production setup with app servers, database, load balancer, firewalls, volumes, and networking.
+
+## Cost Optimization Tips
+
+- **Use ARM64 (cax)** - Best price/performance for compatible workloads
+- **Private networks are free** - No cost for internal traffic
+- **Volumes over local storage** - More flexible, persistent across server changes
+- **Right-size servers** - Start small, scale up as needed
+- **Use labels** - Track costs by project/team
+- **Delete unused resources** - Snapshots, volumes, floating IPs still cost money
+- **Consider location** - German DCs often cheaper than US

--- a/plugins/majestic-devops/skills/hetzner-coder/resources/production-stack.md
+++ b/plugins/majestic-devops/skills/hetzner-coder/resources/production-stack.md
@@ -1,0 +1,210 @@
+# Complete Production Stack
+
+A complete Hetzner Cloud production setup with app servers, database, load balancer, firewalls, and networking.
+
+```hcl
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+  common_labels = {
+    project     = var.project
+    environment = var.environment
+    managed_by  = "opentofu"
+  }
+}
+
+# SSH Key
+resource "hcloud_ssh_key" "deploy" {
+  name       = "${local.name_prefix}-deploy"
+  public_key = file(var.ssh_public_key_path)
+  labels     = local.common_labels
+}
+
+# Private Network
+resource "hcloud_network" "private" {
+  name     = "${local.name_prefix}-network"
+  ip_range = "10.0.0.0/16"
+  labels   = local.common_labels
+}
+
+resource "hcloud_network_subnet" "private" {
+  network_id   = hcloud_network.private.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+# Placement Group for HA
+resource "hcloud_placement_group" "app" {
+  name   = "${local.name_prefix}-spread"
+  type   = "spread"
+  labels = local.common_labels
+}
+
+# App Servers
+resource "hcloud_server" "app" {
+  count = var.app_count
+
+  name               = "${local.name_prefix}-app-${count.index}"
+  server_type        = var.app_server_type
+  image              = "ubuntu-24.04"
+  location           = var.location
+  placement_group_id = hcloud_placement_group.app.id
+  ssh_keys           = [hcloud_ssh_key.deploy.id]
+  backups            = var.environment == "prod"
+
+  network {
+    network_id = hcloud_network.private.id
+  }
+
+  user_data = file("${path.module}/cloud-init.yaml")
+
+  labels = merge(local.common_labels, {
+    role  = "app"
+    index = count.index
+  })
+
+  depends_on = [hcloud_network_subnet.private]
+}
+
+# Database Server
+resource "hcloud_server" "db" {
+  name        = "${local.name_prefix}-db"
+  server_type = var.db_server_type
+  image       = "ubuntu-24.04"
+  location    = var.location
+  ssh_keys    = [hcloud_ssh_key.deploy.id]
+  backups     = true
+
+  network {
+    network_id = hcloud_network.private.id
+    ip         = "10.0.1.10"
+  }
+
+  # No public IP for database
+  public_net {
+    ipv4_enabled = false
+    ipv6_enabled = false
+  }
+
+  labels = merge(local.common_labels, {
+    role = "database"
+  })
+
+  depends_on = [hcloud_network_subnet.private]
+}
+
+# Database Volume
+resource "hcloud_volume" "db_data" {
+  name     = "${local.name_prefix}-db-data"
+  size     = var.db_volume_size
+  location = var.location
+  format   = "ext4"
+  labels   = local.common_labels
+}
+
+resource "hcloud_volume_attachment" "db_data" {
+  volume_id = hcloud_volume.db_data.id
+  server_id = hcloud_server.db.id
+  automount = true
+}
+
+# Firewalls
+resource "hcloud_firewall" "app" {
+  name = "${local.name_prefix}-app-fw"
+
+  rule {
+    description = "SSH"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = var.ssh_allowed_ips
+  }
+
+  rule {
+    description = "HTTP"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "80"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    description = "HTTPS"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "443"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  apply_to {
+    label_selector = "role=app"
+  }
+}
+
+resource "hcloud_firewall" "db" {
+  name = "${local.name_prefix}-db-fw"
+
+  rule {
+    description = "PostgreSQL from private network"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "5432"
+    source_ips  = ["10.0.0.0/16"]
+  }
+
+  apply_to {
+    label_selector = "role=database"
+  }
+}
+
+# Load Balancer
+resource "hcloud_load_balancer" "app" {
+  name               = "${local.name_prefix}-lb"
+  load_balancer_type = "lb11"
+  location           = var.location
+  labels             = local.common_labels
+}
+
+resource "hcloud_load_balancer_network" "app" {
+  load_balancer_id = hcloud_load_balancer.app.id
+  network_id       = hcloud_network.private.id
+}
+
+resource "hcloud_load_balancer_service" "http" {
+  load_balancer_id = hcloud_load_balancer.app.id
+  protocol         = "http"
+  listen_port      = 80
+  destination_port = 3000
+
+  health_check {
+    protocol = "http"
+    port     = 3000
+    interval = 10
+    timeout  = 5
+  }
+}
+
+resource "hcloud_load_balancer_target" "app" {
+  count = var.app_count
+
+  load_balancer_id = hcloud_load_balancer.app.id
+  type             = "server"
+  server_id        = hcloud_server.app[count.index].id
+  use_private_ip   = true
+
+  depends_on = [hcloud_load_balancer_network.app]
+}
+
+# Outputs
+output "load_balancer_ip" {
+  value = hcloud_load_balancer.app.ipv4
+}
+
+output "app_ips" {
+  value = hcloud_server.app[*].ipv4_address
+}
+
+output "db_private_ip" {
+  value = one(hcloud_server.db.network[*].ip)
+}
+```

--- a/plugins/majestic-devops/skills/opentofu-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/opentofu-coder/SKILL.md
@@ -508,3 +508,4 @@ For detailed patterns and examples:
 - `resources/hcl-patterns.md` - Advanced HCL patterns
 - `resources/state-management.md` - State operations and encryption
 - `resources/provider-examples.md` - Multi-cloud provider configs
+- `resources/makefile-automation.md` - Makefile workflows for plan/apply/destroy

--- a/plugins/majestic-devops/skills/opentofu-coder/resources/makefile-automation.md
+++ b/plugins/majestic-devops/skills/opentofu-coder/resources/makefile-automation.md
@@ -1,0 +1,313 @@
+# Makefile Automation for OpenTofu
+
+## Why Makefile?
+
+Makefiles provide:
+- Consistent CLI interface across teams
+- Variable injection and defaults
+- Secret loading integration (1Password, Vault)
+- Guard rails against misuse
+- Self-documenting targets
+
+## Basic Structure
+
+```makefile
+# Define known targets
+TARGETS := apply plan destroy output help
+CATCH_ALL := $(filter-out $(TARGETS),$(MAKECMDGOALS))
+
+# Parse workspace/stack from command line
+STACK_PATH := $(firstword $(CATCH_ALL))
+WORKSPACE := $(firstword $(subst /, ,$(STACK_PATH)))
+STACK := $(word 2,$(subst /, ,$(STACK_PATH)))
+
+# Defaults
+AWS_REGION ?= us-east-1
+TOFU ?= tofu
+
+# Variable arguments passed to all commands
+VAR_ARGS = -var="workspace=$(WORKSPACE)" -var="stack=$(STACK)" -var="aws_region=$(AWS_REGION)"
+
+.PHONY: apply plan destroy output help guard
+
+plan: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) plan $(VAR_ARGS)
+
+apply: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) apply $(VAR_ARGS)
+
+destroy: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) destroy $(VAR_ARGS)
+
+output: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) output $(VAR_ARGS)
+
+help:
+	@echo "Usage: make <target> <workspace>/<stack>"
+	@echo "Targets: apply plan destroy output"
+	@echo "Example: make plan production/core"
+
+guard:
+	@if [ -z "$(WORKSPACE)" ] || [ -z "$(STACK)" ]; then \
+		echo "Usage: make <target> <workspace>/<stack>"; \
+		exit 1; \
+	fi
+
+# Catch-all to ignore workspace/stack as targets
+%:
+	@:
+```
+
+## Usage Pattern
+
+```bash
+# Preview changes
+make plan shared/backend
+make plan production/core
+
+# Apply changes
+make apply production/core
+
+# Destroy (with confirmation)
+make destroy staging/app
+
+# View outputs
+make output production/core
+```
+
+## Secret Loading with 1Password
+
+```makefile
+OP ?= op
+OP_ENV_FILE ?= .op.env
+
+# Prefix commands with secret loading
+CMD_PREFIX = $(OP) run --env-file=$(OP_ENV_FILE) --
+
+plan: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) plan $(VAR_ARGS)
+
+apply: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) apply $(VAR_ARGS)
+```
+
+## Dynamic Variable Injection
+
+```makefile
+# Auto-detect current IP for database whitelisting
+MY_IP := $(shell curl -s ifconfig.me)
+VAR_ARGS = -var="workspace=$(WORKSPACE)" \
+           -var="stack=$(STACK)" \
+           -var='db_allowed_ips=["$(MY_IP)"]'
+
+# Environment-specific overrides
+ifeq ($(WORKSPACE),production)
+  VAR_ARGS += -var="instance_size=large"
+endif
+```
+
+## Output Extraction
+
+```makefile
+# JSON output for scripting
+output-json: guard
+	@$(TOFU) -chdir=$(WORKSPACE)/$(STACK) output -json $(VAR_ARGS)
+
+# Key-value format for shell scripts
+output-raw: guard
+	@$(TOFU) -chdir=$(WORKSPACE)/$(STACK) output -json $(VAR_ARGS) | \
+		jq -r 'to_entries[] | "\(.key)=\(.value.value)"'
+
+# Single value extraction
+get-%: guard
+	@$(TOFU) -chdir=$(WORKSPACE)/$(STACK) output -raw $* $(VAR_ARGS)
+```
+
+Usage:
+```bash
+# Get all outputs as JSON
+make output-json production/core
+
+# Get specific value
+make get-app_ip production/core
+```
+
+## Init with Backend Config
+
+```makefile
+init: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) init \
+		-backend-config="bucket=$(STATE_BUCKET)" \
+		-backend-config="key=$(WORKSPACE)/$(STACK)/terraform.tfstate" \
+		-backend-config="region=$(AWS_REGION)"
+
+# Reconfigure backend
+reinit: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) init -reconfigure
+```
+
+## Validation and Formatting
+
+```makefile
+validate: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) validate
+
+fmt:
+	$(TOFU) fmt -recursive
+
+fmt-check:
+	$(TOFU) fmt -recursive -check
+
+# Pre-commit hook integration
+check: fmt-check
+	@for dir in */*/; do \
+		echo "Validating $$dir..."; \
+		$(TOFU) -chdir=$$dir validate || exit 1; \
+	done
+```
+
+## State Operations
+
+```makefile
+state-list: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) state list
+
+state-show: guard
+	@if [ -z "$(RESOURCE)" ]; then \
+		echo "Usage: make state-show RESOURCE=aws_instance.web production/core"; \
+		exit 1; \
+	fi
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) state show $(RESOURCE)
+
+# Backup state before dangerous operations
+state-backup: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) state pull > \
+		$(WORKSPACE)-$(STACK)-$(shell date +%Y%m%d-%H%M%S).tfstate
+```
+
+## Lock Management
+
+```makefile
+# Force unlock (dangerous - use with caution)
+unlock: guard
+	@if [ -z "$(LOCK_ID)" ]; then \
+		echo "Usage: make unlock LOCK_ID=xxx production/core"; \
+		exit 1; \
+	fi
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) force-unlock $(LOCK_ID)
+```
+
+## Multi-Stack Operations
+
+```makefile
+STACKS := shared/backend production/core staging/core
+
+plan-all:
+	@for stack in $(STACKS); do \
+		echo "=== Planning $$stack ==="; \
+		$(MAKE) plan $$stack || exit 1; \
+	done
+
+# Parallel planning (independent stacks only)
+plan-parallel:
+	@echo "shared/backend production/core" | xargs -P2 -n1 $(MAKE) plan
+```
+
+## Directory Structure Convention
+
+```
+project/
+├── Makefile              # Root automation
+├── .op.env               # 1Password references
+├── providers.tf          # Shared provider config (symlinked)
+├── shared_variables.tf   # Shared variable validation (symlinked)
+├── shared/
+│   └── backend/          # State infrastructure
+│       ├── main.tf
+│       ├── backend.tf
+│       ├── providers.tf  → ../../providers.tf
+│       └── shared_variables.tf → ../../shared_variables.tf
+├── production/
+│   └── core/
+│       ├── main.tf
+│       ├── backend.tf
+│       ├── variables.tf
+│       ├── outputs.tf
+│       ├── providers.tf  → ../../providers.tf
+│       └── shared_variables.tf → ../../shared_variables.tf
+└── staging/
+    └── core/
+        └── ...
+```
+
+## Complete Production Makefile
+
+```makefile
+TARGETS := apply plan destroy output output-raw init validate fmt help
+CATCH_ALL := $(filter-out $(TARGETS),$(MAKECMDGOALS))
+STACK_PATH := $(firstword $(CATCH_ALL))
+WORKSPACE := $(firstword $(subst /, ,$(STACK_PATH)))
+STACK := $(word 2,$(subst /, ,$(STACK_PATH)))
+
+AWS_REGION ?= us-east-1
+OP ?= op
+OP_ENV_FILE ?= .op.env
+TOFU ?= tofu
+MY_IP := $(shell curl -s ifconfig.me 2>/dev/null || echo "0.0.0.0")
+
+CMD_PREFIX = AWS_REGION=$(AWS_REGION) $(OP) run --env-file=$(OP_ENV_FILE) --
+VAR_ARGS = -var="workspace=$(WORKSPACE)" -var="stack=$(STACK)" -var="aws_region=$(AWS_REGION)"
+
+.PHONY: $(TARGETS) guard
+
+plan: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) plan $(VAR_ARGS)
+
+apply: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) apply $(VAR_ARGS)
+
+destroy: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) destroy $(VAR_ARGS)
+
+output: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) output $(VAR_ARGS)
+
+output-raw: guard
+	@$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) output -json $(VAR_ARGS) | \
+		jq -r 'to_entries[] | "\(.key) = \(.value.value)"'
+
+init: guard
+	$(CMD_PREFIX) $(TOFU) -chdir=$(WORKSPACE)/$(STACK) init
+
+validate: guard
+	$(TOFU) -chdir=$(WORKSPACE)/$(STACK) validate
+
+fmt:
+	$(TOFU) fmt -recursive
+
+help:
+	@echo "Usage: make <target> <workspace>/<stack>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  plan      Preview infrastructure changes"
+	@echo "  apply     Apply infrastructure changes"
+	@echo "  destroy   Destroy infrastructure"
+	@echo "  output    Show stack outputs"
+	@echo "  init      Initialize stack backend"
+	@echo "  validate  Validate configuration"
+	@echo "  fmt       Format all .tf files"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan shared/backend"
+	@echo "  make apply production/core"
+
+guard:
+	@if [ -z "$(WORKSPACE)" ] || [ -z "$(STACK)" ]; then \
+		echo "Error: Missing workspace/stack argument"; \
+		echo "Usage: make <target> <workspace>/<stack>"; \
+		exit 1; \
+	fi
+
+%:
+	@:
+```

--- a/plugins/majestic-devops/skills/wrangler-coder/SKILL.md
+++ b/plugins/majestic-devops/skills/wrangler-coder/SKILL.md
@@ -1,0 +1,454 @@
+---
+name: wrangler-coder
+description: This skill guides Cloudflare Workers and Pages development with Wrangler CLI. Use when creating Workers, configuring D1 databases, R2 storage, KV namespaces, Queues, or deploying to Cloudflare Pages.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# Wrangler Coder
+
+## Overview
+
+Wrangler is Cloudflare's official CLI for Workers, Pages, D1, R2, KV, Queues, and AI. This skill covers Wrangler configuration patterns and deployment workflows.
+
+## Installation
+
+```bash
+# npm
+npm install -g wrangler
+
+# pnpm
+pnpm add -g wrangler
+
+# Verify installation
+wrangler --version
+```
+
+## Authentication
+
+```bash
+# Interactive login (opens browser)
+wrangler login
+
+# Check authentication status
+wrangler whoami
+
+# Logout
+wrangler logout
+```
+
+**Environment Variables:**
+
+```bash
+# API Token (preferred for CI/CD)
+export CLOUDFLARE_API_TOKEN="your-api-token"
+
+# Or with 1Password
+CLOUDFLARE_API_TOKEN=op://Infrastructure/Cloudflare/wrangler_token
+
+# Account ID (optional, can be in wrangler.toml)
+export CLOUDFLARE_ACCOUNT_ID="your-account-id"
+```
+
+## Project Initialization
+
+```bash
+# Create new Worker project
+wrangler init my-worker
+
+# Create from template
+wrangler init my-worker --template cloudflare/worker-template
+
+# Initialize in existing directory
+wrangler init
+```
+
+## wrangler.toml Configuration
+
+### Basic Worker
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# Account ID (can also use CLOUDFLARE_ACCOUNT_ID env var)
+account_id = "your-account-id"
+
+# Worker settings
+workers_dev = true  # Enable *.workers.dev subdomain
+```
+
+### Worker with Routes
+
+```toml
+name = "api-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+account_id = "your-account-id"
+
+# Custom domain routes
+routes = [
+  { pattern = "api.example.com/*", zone_name = "example.com" },
+  { pattern = "example.com/api/*", zone_name = "example.com" }
+]
+
+# Or single route
+# route = { pattern = "api.example.com/*", zone_name = "example.com" }
+```
+
+### Worker with Custom Domain
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+account_id = "your-account-id"
+
+# Custom domains (requires DNS to be on Cloudflare)
+[env.production]
+routes = [
+  { pattern = "api.example.com", custom_domain = true }
+]
+```
+
+### Multi-Environment Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+account_id = "your-account-id"
+
+# Development (default)
+workers_dev = true
+
+# Staging environment
+[env.staging]
+name = "my-worker-staging"
+routes = [
+  { pattern = "staging-api.example.com/*", zone_name = "example.com" }
+]
+vars = { ENVIRONMENT = "staging" }
+
+# Production environment
+[env.production]
+name = "my-worker-production"
+routes = [
+  { pattern = "api.example.com/*", zone_name = "example.com" }
+]
+vars = { ENVIRONMENT = "production" }
+```
+
+## KV Namespaces
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# KV namespace bindings
+[[kv_namespaces]]
+binding = "CACHE"
+id = "your-kv-namespace-id"
+preview_id = "your-preview-kv-namespace-id"  # For wrangler dev
+
+[[kv_namespaces]]
+binding = "SESSIONS"
+id = "another-namespace-id"
+```
+
+### CLI Commands
+
+```bash
+# Create namespace
+wrangler kv:namespace create CACHE
+wrangler kv:namespace create CACHE --preview  # For development
+
+# List namespaces
+wrangler kv:namespace list
+
+# Put/Get/Delete values
+wrangler kv:key put --namespace-id=xxx "my-key" "my-value"
+wrangler kv:key get --namespace-id=xxx "my-key"
+wrangler kv:key delete --namespace-id=xxx "my-key"
+
+# Bulk operations
+wrangler kv:bulk put --namespace-id=xxx ./data.json
+wrangler kv:bulk delete --namespace-id=xxx ./keys.json
+```
+
+### Usage in Worker
+
+```typescript
+export interface Env {
+  CACHE: KVNamespace;
+  SESSIONS: KVNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Get value
+    const cached = await env.CACHE.get("key");
+
+    // Get with metadata
+    const { value, metadata } = await env.CACHE.getWithMetadata("key");
+
+    // Put value with expiration
+    await env.CACHE.put("key", "value", {
+      expirationTtl: 3600,  // 1 hour
+      metadata: { version: 1 }
+    });
+
+    // List keys
+    const keys = await env.CACHE.list({ prefix: "user:" });
+
+    // Delete
+    await env.CACHE.delete("key");
+
+    return new Response("OK");
+  }
+};
+```
+
+## D1 Database & R2 Storage
+
+See [resources/d1-r2.md](resources/d1-r2.md) for D1 database (migrations, queries, batch operations) and R2 object storage (upload, download, delete) configuration and usage.
+
+## Queues & Durable Objects
+
+See [resources/queues-durable-objects.md](resources/queues-durable-objects.md) for Queues (producers, consumers, dead letter queues) and Durable Objects (stateful edge storage) configuration and usage.
+
+## Workers AI
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[ai]
+binding = "AI"
+```
+
+### Usage
+
+```typescript
+export interface Env {
+  AI: Ai;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Text generation
+    const response = await env.AI.run("@cf/meta/llama-2-7b-chat-int8", {
+      prompt: "What is Cloudflare Workers?",
+    });
+
+    // Image generation
+    const image = await env.AI.run("@cf/stabilityai/stable-diffusion-xl-base-1.0", {
+      prompt: "A cat wearing sunglasses",
+    });
+
+    // Text embeddings
+    const embeddings = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+      text: ["Hello world", "Goodbye world"],
+    });
+
+    return Response.json(response);
+  }
+};
+```
+
+## Secrets Management
+
+### CLI Commands
+
+```bash
+# Add secret
+wrangler secret put API_KEY
+# (prompts for value)
+
+# Add secret for specific environment
+wrangler secret put API_KEY --env production
+
+# List secrets
+wrangler secret list
+
+# Delete secret
+wrangler secret delete API_KEY
+
+# Bulk secrets from .dev.vars file (local dev only)
+# Create .dev.vars file:
+# API_KEY=xxx
+# DB_PASSWORD=yyy
+```
+
+### Usage
+
+```typescript
+export interface Env {
+  API_KEY: string;
+  DB_PASSWORD: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Access secrets from env
+    const apiKey = env.API_KEY;
+    return new Response(`Key length: ${apiKey.length}`);
+  }
+};
+```
+
+## Development Workflow
+
+### Local Development
+
+```bash
+# Start local dev server
+wrangler dev
+
+# With specific environment
+wrangler dev --env staging
+
+# Custom port
+wrangler dev --port 8787
+
+# Remote mode (uses Cloudflare's network)
+wrangler dev --remote
+
+# Local mode with persistent storage
+wrangler dev --persist-to ./data
+```
+
+### Testing
+
+```bash
+# Run tests with vitest (recommended)
+npm install -D vitest @cloudflare/vitest-pool-workers
+
+# vitest.config.ts
+# import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+# export default defineWorkersConfig({
+#   test: { poolOptions: { workers: { wrangler: { configPath: './wrangler.toml' } } } }
+# });
+```
+
+### Deployment
+
+```bash
+# Deploy to workers.dev
+wrangler deploy
+
+# Deploy to specific environment
+wrangler deploy --env production
+
+# Dry run (show what would be deployed)
+wrangler deploy --dry-run
+
+# Deploy with custom name
+wrangler deploy --name my-custom-worker
+```
+
+### Logs and Debugging
+
+```bash
+# Tail logs (real-time)
+wrangler tail
+
+# Tail specific environment
+wrangler tail --env production
+
+# Filter logs
+wrangler tail --status error
+wrangler tail --search "user-id-123"
+wrangler tail --ip 1.2.3.4
+
+# View deployment versions
+wrangler versions list
+
+# Rollback to previous version
+wrangler rollback
+```
+
+## Cloudflare Pages
+
+### Configuration (wrangler.toml for Functions)
+
+```toml
+name = "my-site"
+compatibility_date = "2024-12-01"
+pages_build_output_dir = "./dist"
+
+[[kv_namespaces]]
+binding = "CACHE"
+id = "your-namespace-id"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "your-database-id"
+```
+
+### CLI Commands
+
+```bash
+# Create Pages project
+wrangler pages project create my-site
+
+# Deploy
+wrangler pages deploy ./dist
+
+# Deploy to specific branch/environment
+wrangler pages deploy ./dist --branch main
+wrangler pages deploy ./dist --branch staging
+
+# List deployments
+wrangler pages deployment list --project-name my-site
+
+# Tail logs
+wrangler pages deployment tail --project-name my-site
+```
+
+### Pages Functions
+
+```
+project/
+├── functions/
+│   ├── api/
+│   │   └── [[route]].ts  # Catch-all: /api/*
+│   ├── hello.ts          # /hello
+│   └── _middleware.ts    # Middleware for all routes
+├── public/
+└── wrangler.toml
+```
+
+```typescript
+// functions/api/[[route]].ts
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request, env, params } = context;
+  const route = params.route;  // Array of path segments
+
+  return Response.json({ route });
+};
+```
+
+## Complete Worker Example
+
+See [resources/worker-example.md](resources/worker-example.md) for a production-ready Worker with D1, KV, R2 bindings, multi-environment config, and CORS handling.
+
+## Best Practices
+
+- **Pin compatibility_date** - Ensures reproducible behavior across deployments
+- **Use environments** - Separate staging/production configs in same file
+- **Secrets via CLI** - Never commit secrets, use `wrangler secret put`
+- **Local persistence** - Use `--persist-to` for consistent local dev state
+- **Tail logs in production** - Debug issues with `wrangler tail --status error`
+- **Version control wrangler.toml** - Track configuration changes
+- **Use .dev.vars for local secrets** - Add to .gitignore
+- **Batch D1 operations** - Reduce latency with `env.DB.batch()`
+- **Cache strategically** - Use KV for frequently accessed data
+- **Handle errors gracefully** - Return proper HTTP status codes

--- a/plugins/majestic-devops/skills/wrangler-coder/resources/d1-r2.md
+++ b/plugins/majestic-devops/skills/wrangler-coder/resources/d1-r2.md
@@ -1,0 +1,170 @@
+# D1 Database & R2 Storage
+
+## D1 Database
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "your-database-id"
+```
+
+### CLI Commands
+
+```bash
+# Create database
+wrangler d1 create my-database
+
+# List databases
+wrangler d1 list
+
+# Execute SQL
+wrangler d1 execute my-database --command "SELECT * FROM users"
+wrangler d1 execute my-database --file ./schema.sql
+
+# Local development (uses local SQLite)
+wrangler d1 execute my-database --local --command "SELECT * FROM users"
+
+# Export database
+wrangler d1 export my-database --output backup.sql
+
+# Migrations
+wrangler d1 migrations create my-database "add_users_table"
+wrangler d1 migrations apply my-database
+wrangler d1 migrations apply my-database --local  # Local dev
+```
+
+### Migrations
+
+```
+migrations/
+├── 0001_create_users.sql
+├── 0002_add_posts.sql
+└── 0003_add_indexes.sql
+```
+
+```sql
+-- migrations/0001_create_users.sql
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_users_email ON users(email);
+```
+
+### Usage in Worker
+
+```typescript
+export interface Env {
+  DB: D1Database;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Query
+    const { results } = await env.DB.prepare(
+      "SELECT * FROM users WHERE id = ?"
+    ).bind(1).all();
+
+    // Insert
+    const result = await env.DB.prepare(
+      "INSERT INTO users (email, name) VALUES (?, ?)"
+    ).bind("user@example.com", "John").run();
+
+    // Batch operations
+    const batch = await env.DB.batch([
+      env.DB.prepare("INSERT INTO users (email) VALUES (?)").bind("a@example.com"),
+      env.DB.prepare("INSERT INTO users (email) VALUES (?)").bind("b@example.com"),
+    ]);
+
+    return Response.json({ users: results });
+  }
+};
+```
+
+## R2 Storage
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "my-bucket"
+preview_bucket_name = "my-bucket-preview"  # For wrangler dev
+```
+
+### CLI Commands
+
+```bash
+# Create bucket
+wrangler r2 bucket create my-bucket
+
+# List buckets
+wrangler r2 bucket list
+
+# Object operations
+wrangler r2 object put my-bucket/path/to/file.txt --file ./local-file.txt
+wrangler r2 object get my-bucket/path/to/file.txt
+wrangler r2 object delete my-bucket/path/to/file.txt
+
+# List objects
+wrangler r2 object list my-bucket --prefix "uploads/"
+```
+
+### Usage in Worker
+
+```typescript
+export interface Env {
+  BUCKET: R2Bucket;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const key = url.pathname.slice(1);
+
+    switch (request.method) {
+      case "GET": {
+        const object = await env.BUCKET.get(key);
+        if (!object) return new Response("Not found", { status: 404 });
+
+        return new Response(object.body, {
+          headers: {
+            "Content-Type": object.httpMetadata?.contentType || "application/octet-stream",
+            "ETag": object.httpEtag,
+          }
+        });
+      }
+
+      case "PUT": {
+        await env.BUCKET.put(key, request.body, {
+          httpMetadata: {
+            contentType: request.headers.get("Content-Type") || "application/octet-stream",
+          }
+        });
+        return new Response("Created", { status: 201 });
+      }
+
+      case "DELETE": {
+        await env.BUCKET.delete(key);
+        return new Response("Deleted", { status: 200 });
+      }
+    }
+
+    return new Response("Method not allowed", { status: 405 });
+  }
+};
+```

--- a/plugins/majestic-devops/skills/wrangler-coder/resources/queues-durable-objects.md
+++ b/plugins/majestic-devops/skills/wrangler-coder/resources/queues-durable-objects.md
@@ -1,0 +1,145 @@
+# Queues & Durable Objects
+
+## Queues
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# Producer binding
+[[queues.producers]]
+binding = "MY_QUEUE"
+queue = "my-queue"
+
+# Consumer binding
+[[queues.consumers]]
+queue = "my-queue"
+max_batch_size = 10
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "my-dlq"
+```
+
+### CLI Commands
+
+```bash
+# Create queue
+wrangler queues create my-queue
+wrangler queues create my-dlq  # Dead letter queue
+
+# List queues
+wrangler queues list
+
+# Delete queue
+wrangler queues delete my-queue
+```
+
+### Usage in Worker
+
+```typescript
+export interface Env {
+  MY_QUEUE: Queue;
+}
+
+interface MyMessage {
+  userId: string;
+  action: string;
+}
+
+export default {
+  // Producer: Send messages to queue
+  async fetch(request: Request, env: Env): Promise<Response> {
+    await env.MY_QUEUE.send({
+      userId: "123",
+      action: "signup"
+    });
+
+    // Batch send
+    await env.MY_QUEUE.sendBatch([
+      { body: { userId: "1", action: "a" } },
+      { body: { userId: "2", action: "b" } },
+    ]);
+
+    return new Response("Queued");
+  },
+
+  // Consumer: Process messages
+  async queue(batch: MessageBatch<MyMessage>, env: Env): Promise<void> {
+    for (const message of batch.messages) {
+      try {
+        console.log(`Processing: ${message.body.userId}`);
+        // Process message...
+        message.ack();
+      } catch (error) {
+        message.retry();  // Will retry or go to DLQ
+      }
+    }
+  }
+};
+```
+
+## Durable Objects
+
+### Configuration
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[[durable_objects.bindings]]
+name = "COUNTER"
+class_name = "Counter"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["Counter"]
+```
+
+### Implementation
+
+```typescript
+export interface Env {
+  COUNTER: DurableObjectNamespace;
+}
+
+export class Counter {
+  private state: DurableObjectState;
+  private value: number = 0;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+    this.state.blockConcurrencyWhile(async () => {
+      this.value = (await this.state.storage.get("value")) || 0;
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    switch (url.pathname) {
+      case "/increment":
+        this.value++;
+        await this.state.storage.put("value", this.value);
+        return new Response(String(this.value));
+
+      case "/value":
+        return new Response(String(this.value));
+
+      default:
+        return new Response("Not found", { status: 404 });
+    }
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.COUNTER.idFromName("global");
+    const stub = env.COUNTER.get(id);
+    return stub.fetch(request);
+  }
+};
+```

--- a/plugins/majestic-devops/skills/wrangler-coder/resources/worker-example.md
+++ b/plugins/majestic-devops/skills/wrangler-coder/resources/worker-example.md
@@ -1,0 +1,113 @@
+# Complete Worker Example
+
+A production-ready Cloudflare Worker with D1, KV, R2 bindings, multi-environment config, and CORS handling.
+
+## wrangler.toml
+
+```toml
+name = "my-api"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+APP_NAME = "My API"
+
+[[kv_namespaces]]
+binding = "CACHE"
+id = "xxx"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-db"
+database_id = "xxx"
+
+[[r2_buckets]]
+binding = "STORAGE"
+bucket_name = "my-bucket"
+
+[env.staging]
+name = "my-api-staging"
+vars = { ENVIRONMENT = "staging" }
+routes = [
+  { pattern = "staging-api.example.com/*", zone_name = "example.com" }
+]
+
+[env.production]
+name = "my-api-production"
+vars = { ENVIRONMENT = "production" }
+routes = [
+  { pattern = "api.example.com/*", zone_name = "example.com" }
+]
+```
+
+## src/index.ts
+
+```typescript
+export interface Env {
+  APP_NAME: string;
+  ENVIRONMENT: string;
+  CACHE: KVNamespace;
+  DB: D1Database;
+  STORAGE: R2Bucket;
+  API_KEY: string;  // Secret
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS headers
+    const corsHeaders = {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    };
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+
+    try {
+      // Route handling
+      if (url.pathname === "/health") {
+        return Response.json({
+          status: "ok",
+          app: env.APP_NAME,
+          environment: env.ENVIRONMENT
+        }, { headers: corsHeaders });
+      }
+
+      if (url.pathname.startsWith("/api/users")) {
+        return handleUsers(request, env, corsHeaders);
+      }
+
+      return new Response("Not found", { status: 404, headers: corsHeaders });
+
+    } catch (error) {
+      console.error("Error:", error);
+      return Response.json(
+        { error: "Internal server error" },
+        { status: 500, headers: corsHeaders }
+      );
+    }
+  }
+};
+
+async function handleUsers(request: Request, env: Env, headers: HeadersInit): Promise<Response> {
+  if (request.method === "GET") {
+    const { results } = await env.DB.prepare("SELECT * FROM users").all();
+    return Response.json({ users: results }, { headers });
+  }
+
+  if (request.method === "POST") {
+    const body = await request.json<{ email: string; name: string }>();
+    await env.DB.prepare("INSERT INTO users (email, name) VALUES (?, ?)")
+      .bind(body.email, body.name)
+      .run();
+    return Response.json({ success: true }, { status: 201, headers });
+  }
+
+  return new Response("Method not allowed", { status: 405, headers });
+}
+```


### PR DESCRIPTION
## Summary

Expands the majestic-devops plugin with comprehensive cloud provider skills and Cloudflare integration.

### Cloud Provider Skills
- **digitalocean-coder**: VPC, Droplets, Databases, Firewalls, Reserved IPs
- **hetzner-coder**: Servers (cx/cpx/cax/ccx), Networks, Load Balancers, Volumes
- **cloud-init-coder**: VM provisioning with user-data, SSH hardening, Docker setup
- **1password-cli-coder**: Secret management with `.op.env`, Makefile, CI/CD integration

### Cloudflare Skills
- **cloudflare-coder**: OpenTofu/Terraform patterns for Cloudflare infrastructure
  - Zone and DNS management
  - SSL/TLS strict mode, HSTS, TLS 1.3
  - WAF custom rules and managed rulesets
  - Cache rules (modern rulesets over legacy Page Rules)
  - Load balancer configuration
- **wrangler-coder**: Cloudflare Workers and Pages development
  - wrangler.toml configuration patterns
  - Multi-environment setup (staging/production)
  - KV, D1, R2, Queues, Durable Objects
  - Workers AI integration
  - Pages Functions patterns

### Security
- **infra-security-review** agent: IaC security audits for state backend, secrets, network, compute

## Test plan

- [ ] Verify skills are auto-discovered by Claude Code
- [ ] Test `cloudflare-coder` triggers on Terraform/Cloudflare work
- [ ] Test `wrangler-coder` triggers on wrangler.toml configuration
- [ ] Verify README documentation is accurate