### PR TITLE
fix(blueprint): open plan in editor when auto_preview is enabled

### DIFF
--- a/plugins/majestic-engineer/commands/workflows/blueprint.md
+++ b/plugins/majestic-engineer/commands/workflows/blueprint.md
@@ -178,7 +178,7 @@ Incorporate feedback and update the plan file.
 Skill(skill: "config-reader", args: "auto_preview false")
 ```
 
-If `auto_preview` is `true`: Show plan content using `Read(file_path="docs/plans/<filename>.md")`
+If `auto_preview` is `true`: Execute `open docs/plans/<filename>.md`
 
 **MANDATORY: Use AskUserQuestion to present options:**
 


### PR DESCRIPTION
## Summary
• Fixed `blueprint` command's auto_preview behavior to actually open files in editor
• Changed from using `Read()` tool (terminal display) to `open` command (editor)
• Now consistent with `handoff`, `prd`, and `ux-brief` commands which already use this pattern

## Problem
The `/majestic:blueprint` command was configured to auto_preview the created plan file, but instead of opening it in the user's editor, it was only displaying content in the terminal via the `Read()` tool.

## Solution
Updated line 181 in `blueprint.md` to execute `open docs/plans/<filename>.md` instead of calling `Read()`, matching the documented pattern in `CONFIG-SYSTEM.md` and the behavior of other similar commands.

## Test plan
- [ ] Run `/majestic:blueprint` with `auto_preview: true` in `.agents.yml`
- [ ] Verify plan file opens in default editor after blueprint creation
- [ ] Confirm behavior matches other commands (handoff, prd, ux-brief)