### PR TITLE
feat(ralph): add majestic-ralph plugin for autonomous AI coding loops

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Majestic Labs plugin marketplace for Claude Code extensions",
-    "version": "3.2.0"
+    "version": "3.3.0"
   },
   "plugins": [
     {
@@ -438,6 +438,29 @@
         "indie-hacker"
       ],
       "source": "./plugins/majestic-founder"
+    },
+    {
+      "name": "majestic-ralph",
+      "description": "Autonomous AI coding loops. Ship features while you sleep with iterative prompts that compound learnings. Includes 3 commands, 1 skill, and stop hook.",
+      "version": "1.0.0",
+      "author": {
+        "name": "David Paluy",
+        "url": "https://github.com/dpaluy",
+        "email": "marketplace@it.majesticlabs.dev"
+      },
+      "homepage": "https://github.com/majesticlabs-dev/majestic-marketplace/tree/master/plugins/majestic-ralph",
+      "tags": [
+        "ralph",
+        "autonomous",
+        "iteration",
+        "loop",
+        "agentic",
+        "ship-while-sleeping",
+        "tdd",
+        "learnings",
+        "compound"
+      ],
+      "source": "./plugins/majestic-ralph"
     }
   ]
 }

--- a/plugins/majestic-engineer/commands/workflows/run-blueprint.md
+++ b/plugins/majestic-engineer/commands/workflows/run-blueprint.md
@@ -45,7 +45,7 @@ Check if already running inside ralph-loop:
 **If NOT in loop:** Invoke ralph-loop with run-blueprint as the prompt:
 
 ```
-Skill(skill: "ralph-loop:ralph-loop", args: '"/majestic:run-blueprint <blueprint_file>" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"')
+Skill(skill: "majestic-ralph:start", args: '"/majestic:run-blueprint <blueprint_file>" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"')
 ```
 
 Then **STOP** - ralph-loop will re-invoke this command and handle iterations.
@@ -174,7 +174,7 @@ This command is designed to work with ralph-loop for autonomous iteration.
 
 **Start with ralph:**
 ```bash
-/ralph-loop:ralph-loop "/majestic:run-blueprint docs/plans/xxx.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+/majestic-ralph:start "/majestic:run-blueprint docs/plans/xxx.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
 ```
 
 **Completion signal:** Output `<promise>RUN_BLUEPRINT_COMPLETE</promise>` when:
@@ -247,5 +247,5 @@ Please fix dependencies in blueprint file before continuing.
 /majestic:run-blueprint docs/plans/20241228_add-auth.md
 
 # With ralph-loop for autonomous execution
-/ralph-loop:ralph-loop "/majestic:run-blueprint docs/plans/20241228_add-auth.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+/majestic-ralph:start "/majestic:run-blueprint docs/plans/20241228_add-auth.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
 ```

--- a/plugins/majestic-ralph/.claude-plugin/plugin.json
+++ b/plugins/majestic-ralph/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "majestic-ralph",
+  "version": "1.0.0",
+  "description": "Autonomous AI coding loops. Ship features while you sleep with iterative prompts that compound learnings.",
+  "author": {
+    "name": "David Paluy",
+    "url": "https://github.com/dpaluy",
+    "email": "marketplace@it.majesticlabs.dev"
+  },
+  "keywords": [
+    "ralph",
+    "autonomous",
+    "iteration",
+    "loop",
+    "agentic",
+    "ship-while-sleeping",
+    "learnings",
+    "tdd"
+  ]
+}

--- a/plugins/majestic-ralph/README.md
+++ b/plugins/majestic-ralph/README.md
@@ -1,0 +1,153 @@
+# majestic-ralph
+
+Autonomous AI coding loops for Claude Code. Ship features while you sleep.
+
+## Overview
+
+Ralph Loop creates a **self-referential feedback loop** where:
+- A single prompt never changes between iterations
+- Your previous work persists in files and git history
+- Each iteration sees modified files and improves upon them
+- Learnings compound in a progress file across iterations
+
+## Installation
+
+```bash
+claude plugins add majestic-ralph
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/majestic-ralph:start "<prompt>"` | Start an autonomous iteration loop |
+| `/majestic-ralph:cancel` | Stop the active loop |
+| `/majestic-ralph:help` | Show help and best practices |
+
+## Quick Start
+
+```bash
+# Basic autonomous loop
+/majestic-ralph:start "Build a login form with validation. Output <promise>DONE</promise> when complete." --max-iterations 20 --completion-promise "DONE"
+
+# With blueprint integration
+/majestic-ralph:start "/majestic:run-blueprint docs/plans/add-auth.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+```
+
+## Options
+
+- `--max-iterations N` - Safety limit (recommended: 10-50)
+- `--completion-promise "<text>"` - Phrase that signals genuine completion
+
+## Files
+
+| File | Purpose | Git |
+|------|---------|-----|
+| `.claude/ralph-loop.local.md` | Loop state (iteration, prompt) | Ignored |
+| `.claude/ralph-progress.local.yml` | Patterns and story log | Ignored |
+
+## Progress File
+
+Learnings compound across iterations via `.claude/ralph-progress.local.yml`:
+
+```yaml
+patterns:
+  migrations: "Use IF NOT EXISTS for all column additions"
+  forms: "Zod schema validation"
+  auth: "Server actions in actions.ts"
+
+stories:
+  - id: US-001
+    title: Add login form
+    completed_at: 2024-01-15T10:45:00Z
+    files:
+      - app/login/page.tsx
+    learnings:
+      - "Form validation uses zod"
+```
+
+**Workflow:**
+1. Read patterns before each iteration
+2. Update after completing each story
+3. Promote valuable patterns to AGENTS.md at loop end
+
+## Best Practices
+
+### 1. Small, Focused Tasks
+```
+✅ "Add login form with email validation"
+❌ "Build entire auth system"
+```
+
+### 2. Explicit Completion Criteria
+```
+"Implement feature X:
+- Acceptance criteria 1
+- Acceptance criteria 2
+- Tests passing
+Output <promise>COMPLETE</promise> when ALL criteria met."
+```
+
+### 3. Include Escape Hatches
+```
+"After 15 iterations, if not complete:
+- Document blockers
+- List attempts
+- Suggest alternatives"
+```
+
+## When to Use
+
+**Good for:**
+- Well-defined tasks with clear success criteria
+- Tasks requiring iteration (getting tests to pass)
+- Greenfield projects you can walk away from
+- Tasks with automatic verification (tests, linters)
+
+**Not good for:**
+- Tasks requiring human judgment
+- Production debugging
+- Unclear success criteria
+
+## Monitoring
+
+```bash
+# Check iteration
+grep '^iteration:' .claude/ralph-loop.local.md
+
+# View patterns
+cat .claude/ralph-progress.local.yml
+
+# Cancel loop
+/majestic-ralph:cancel
+```
+
+## What Makes This Different
+
+| Feature | Other Implementations | majestic-ralph |
+|---------|----------------------|----------------|
+| **Progress format** | Markdown (unstructured) | YAML (structured, parseable) |
+| **Git handling** | Committed to history | Gitignored → promotes to AGENTS.md |
+| **Pattern access** | Buried in narrative | Top-level `patterns:` key |
+| **Blueprint integration** | None | Built-in via `/majestic:run-blueprint` |
+| **Ecosystem** | Standalone | Integrates with majestic-engineer workflows |
+
+### Key Innovation: Ephemeral → Permanent Memory
+
+```
+During loop:     .claude/ralph-progress.local.yml  (gitignored, working memory)
+                              ↓
+After loop:      AGENTS.md patterns section         (committed, permanent)
+```
+
+Learnings compound during the loop, then valuable patterns promote to permanent documentation.
+
+## Credits
+
+Original technique: [Geoffrey Huntley](https://ghuntley.com/ralph)
+
+## Contents
+
+- **Commands:** 3 (`start`, `cancel`, `help`)
+- **Skills:** 1 (ralph-methodology)
+- **Hooks:** 1 (stop hook for loop continuation)

--- a/plugins/majestic-ralph/commands/cancel-ralph.md
+++ b/plugins/majestic-ralph/commands/cancel-ralph.md
@@ -1,0 +1,33 @@
+---
+name: majestic-ralph:cancel
+description: Cancel active Ralph Loop
+allowed-tools: Bash
+---
+
+# Cancel Ralph Loop
+
+Stop the currently running Ralph loop by removing the state file.
+
+## Execute
+
+```bash
+if [ -f .claude/ralph-loop.local.md ]; then
+  ITERATION=$(grep '^iteration:' .claude/ralph-loop.local.md | cut -d' ' -f2)
+  rm .claude/ralph-loop.local.md
+  echo "Ralph loop cancelled at iteration ${ITERATION:-unknown}"
+else
+  echo "No active Ralph loop found"
+fi
+```
+
+## Output
+
+**If loop was active:**
+```
+Ralph loop cancelled at iteration N
+```
+
+**If no loop:**
+```
+No active Ralph loop found
+```

--- a/plugins/majestic-ralph/commands/help.md
+++ b/plugins/majestic-ralph/commands/help.md
@@ -1,0 +1,131 @@
+---
+name: majestic-ralph:help
+description: Explain Ralph Loop plugin and available commands
+---
+
+# Ralph Loop Help
+
+Ralph Loop is an autonomous AI coding system that ships features while you sleep.
+
+## Core Concept
+
+A **self-referential feedback loop** where:
+- A single prompt never changes between iterations
+- Your previous work persists in files and git history
+- Each iteration sees modified files and improves upon them
+- Learnings compound in progress file across iterations
+
+## Available Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/majestic-ralph:start "<prompt>"` | Start an iteration loop |
+| `/majestic-ralph:cancel` | Stop the active loop |
+| `/majestic-ralph:help` | This help message |
+
+## Quick Start
+
+```bash
+# Start a loop with completion promise
+/majestic-ralph:start "Build a login form with validation. Output <promise>DONE</promise> when complete." --max-iterations 20 --completion-promise "DONE"
+```
+
+## Key Options
+
+- `--max-iterations N` - Safety limit (recommended: 10-50)
+- `--completion-promise "TEXT"` - Phrase that signals genuine completion
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `.claude/ralph-loop.local.md` | Loop state (iteration, prompt) |
+| `.claude/ralph-progress.local.yml` | Patterns and story log |
+
+Both are gitignored (`.local.` suffix).
+
+## Progress File
+
+Read at start of each iteration, update after completing work:
+
+```yaml
+patterns:
+  migrations: "Use IF NOT EXISTS"
+  forms: "Zod validation"
+
+stories:
+  - id: US-001
+    title: Add login form
+    files: [app/login/page.tsx]
+    learnings:
+      - "Submit handler in separate action"
+```
+
+Promote valuable patterns to AGENTS.md at loop end.
+
+## Best Practices
+
+### 1. Small, Focused Tasks
+```
+✅ "Add login form with email validation"
+❌ "Build entire auth system"
+```
+
+### 2. Explicit Completion Criteria
+```
+"Implement feature X:
+- Acceptance criteria 1
+- Acceptance criteria 2
+- Tests passing
+Output <promise>COMPLETE</promise> when ALL criteria met."
+```
+
+### 3. Include Escape Hatches
+```
+"After 15 iterations, if not complete:
+- Document what's blocking progress
+- List what was attempted
+- Suggest alternative approaches"
+```
+
+### 4. Use with Blueprints
+```bash
+/majestic-ralph:start "/majestic:run-blueprint docs/plans/feature.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+```
+
+## When to Use Ralph
+
+**Good for:**
+- Well-defined tasks with clear success criteria
+- Tasks requiring iteration (getting tests to pass)
+- Greenfield projects you can walk away from
+- Tasks with automatic verification (tests, linters)
+
+**Not good for:**
+- Tasks requiring human judgment/design decisions
+- One-shot operations
+- Unclear success criteria
+- Production debugging
+
+## Monitoring Progress
+
+```bash
+# Check current iteration
+grep '^iteration:' .claude/ralph-loop.local.md
+
+# View accumulated patterns
+cat .claude/ralph-progress.local.yml
+```
+
+## Philosophy
+
+| Principle | Description |
+|-----------|-------------|
+| **Iteration > Perfection** | Don't aim for perfect first try; let the loop refine |
+| **Failures Are Data** | Each failure informs the next attempt |
+| **Learnings Compound** | By iteration 10, patterns from 1-9 are visible |
+| **Persistence Wins** | Keep trying until genuine success |
+
+## Reference
+
+Original technique: [ghuntley.com/ralph](https://ghuntley.com/ralph)

--- a/plugins/majestic-ralph/commands/ralph-loop.md
+++ b/plugins/majestic-ralph/commands/ralph-loop.md
@@ -1,0 +1,71 @@
+---
+name: majestic-ralph:start
+description: Start Ralph Loop in current session
+argument-hint: '"<prompt>" [--max-iterations N] [--completion-promise "<text>"]'
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)
+hide-from-slash-command-tool: true
+---
+
+# Ralph Loop
+
+Start an autonomous iteration loop that re-feeds the same prompt until completion.
+
+## Input
+
+<arguments> $ARGUMENTS </arguments>
+
+**Format:** `"<prompt>" [--max-iterations N] [--completion-promise "<text>"]`
+
+## How It Works
+
+1. **Task Iteration:** You work on the provided task, tracked in files and git history
+2. **Loop Continuation:** When you try to exit, Ralph re-feeds the **same prompt** back to you
+3. **Learnings Compound:** Each iteration sees previous work via modified files and git history
+4. **Completion Promise:** Output the promise text ONLY when genuinely complete
+
+## Execute Setup
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
+```
+
+## Critical Rules
+
+**Completion Promise Integrity:**
+- You may ONLY output `<promise>YOUR_PHRASE</promise>` when the statement is **completely and unequivocally TRUE**
+- Do NOT output false promises to escape the loop, even if stuck
+- The loop is designed to continue until genuine completion
+
+**State File:**
+- Location: `.claude/ralph-loop.local.md`
+- Contains iteration count, max iterations, completion promise, and prompt
+- Check progress: `grep '^iteration:' .claude/ralph-loop.local.md`
+
+## Examples
+
+```bash
+# Basic autonomous loop
+/ralph "Build a REST API for todos with CRUD, validation, and tests. Output <promise>COMPLETE</promise> when done."
+
+# With iteration limit
+/ralph "Implement feature X" --max-iterations 20 --completion-promise "DONE"
+
+# Blueprint execution
+/ralph "/majestic:run-blueprint docs/plans/add-auth.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+```
+
+## Monitoring
+
+```bash
+# Check current iteration
+grep '^iteration:' .claude/ralph-loop.local.md
+
+# Watch progress
+tail -f .claude/ralph-loop.local.md
+```
+
+## Safety
+
+- Always use `--max-iterations` as a safeguard
+- Include fallback instructions in prompts for stuck scenarios
+- Use `/cancel-ralph` to stop the loop manually

--- a/plugins/majestic-ralph/hooks/hooks.json
+++ b/plugins/majestic-ralph/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Ralph Loop plugin - autonomous iteration via stop hook",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/majestic-ralph/hooks/stop-hook.sh
+++ b/plugins/majestic-ralph/hooks/stop-hook.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph Loop Stop Hook
+# Intercepts session exit and re-feeds the prompt if loop is active
+
+STATE_FILE=".claude/ralph-loop.local.md"
+PROGRESS_FILE=".claude/ralph-progress.local.yml"
+
+# Check if loop is active
+if [ ! -f "$STATE_FILE" ]; then
+  # No active loop - allow normal exit
+  exit 0
+fi
+
+# Parse state file (YAML frontmatter)
+parse_field() {
+  grep "^$1:" "$STATE_FILE" 2>/dev/null | sed "s/^$1: *//" | head -1
+}
+
+ITERATION=$(parse_field "iteration")
+MAX_ITERATIONS=$(parse_field "max_iterations")
+COMPLETION_PROMISE=$(parse_field "completion_promise")
+
+# Validate numeric fields
+if ! [[ "$ITERATION" =~ ^[0-9]+$ ]]; then
+  echo "Error: Invalid iteration count in state file" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+if [ -n "$MAX_ITERATIONS" ] && ! [[ "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
+  echo "Error: Invalid max_iterations in state file" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# Check max iterations limit
+if [ -n "$MAX_ITERATIONS" ] && [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+  echo "Ralph loop reached maximum iterations ($MAX_ITERATIONS)" >&2
+  echo "" >&2
+  echo "Promote valuable patterns from $PROGRESS_FILE to AGENTS.md" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# Get transcript file from environment
+TRANSCRIPT_FILE="${CLAUDE_TRANSCRIPT_FILE:-}"
+if [ -z "$TRANSCRIPT_FILE" ] || [ ! -f "$TRANSCRIPT_FILE" ]; then
+  echo "Error: Cannot read transcript file" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# Extract last assistant message from transcript (JSONL format)
+LAST_ASSISTANT_MSG=$(tac "$TRANSCRIPT_FILE" | grep -m1 '"role":"assistant"' | jq -r '.message.content[] | select(.type == "text") | .text' 2>/dev/null || echo "")
+
+if [ -z "$LAST_ASSISTANT_MSG" ]; then
+  echo "Warning: No assistant message found in transcript" >&2
+fi
+
+# Check for completion promise
+if [ -n "$COMPLETION_PROMISE" ]; then
+  # Look for <promise>COMPLETION_PROMISE</promise> pattern
+  if echo "$LAST_ASSISTANT_MSG" | grep -q "<promise>${COMPLETION_PROMISE}</promise>"; then
+    echo "╔════════════════════════════════════════════════════════════════╗"
+    echo "║              ✅ RALPH LOOP COMPLETE                            ║"
+    echo "╠════════════════════════════════════════════════════════════════╣"
+    echo "║ Promise fulfilled: $COMPLETION_PROMISE"
+    echo "║ Iterations: $ITERATION"
+    echo "╠════════════════════════════════════════════════════════════════╣"
+    echo "║ Next: Promote patterns from ralph-progress.local.yml          ║"
+    echo "║       to relevant AGENTS.md files                             ║"
+    echo "╚════════════════════════════════════════════════════════════════╝"
+    rm -f "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+# Increment iteration counter
+NEW_ITERATION=$((ITERATION + 1))
+
+# Extract prompt from state file (everything after ---\n at end of frontmatter)
+PROMPT=$(awk '/^---$/{if(++n==2){getline; found=1}} found' "$STATE_FILE")
+
+if [ -z "$PROMPT" ]; then
+  echo "Error: No prompt found in state file" >&2
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+# Update iteration count in state file
+sed -i.bak "s/^iteration: .*/iteration: $NEW_ITERATION/" "$STATE_FILE"
+rm -f "$STATE_FILE.bak"
+
+# Build context message
+CONTEXT_MSG="[RALPH LOOP] Iteration $NEW_ITERATION${MAX_ITERATIONS:+ of $MAX_ITERATIONS}
+
+## Before continuing:
+1. Read \`.claude/ralph-progress.local.yml\` for accumulated patterns
+2. Apply learned patterns to avoid repeating mistakes
+
+## After completing work:
+Update \`.claude/ralph-progress.local.yml\` with new patterns and story entry.
+
+---
+
+**TASK:**
+$PROMPT"
+
+# Output JSON to block exit and continue loop
+cat << EOF
+{
+  "decision": "block",
+  "reason": "Ralph loop iteration $NEW_ITERATION${MAX_ITERATIONS:+ of $MAX_ITERATIONS}",
+  "updatedSessionContext": $(echo "$CONTEXT_MSG" | jq -Rs .)
+}
+EOF

--- a/plugins/majestic-ralph/scripts/setup-ralph-loop.sh
+++ b/plugins/majestic-ralph/scripts/setup-ralph-loop.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph Loop Setup Script
+# Creates state file and initializes the iteration loop
+
+STATE_FILE=".claude/ralph-loop.local.md"
+PROGRESS_FILE=".claude/ralph-progress.local.yml"
+STATE_DIR=".claude"
+
+# Initialize variables
+PROMPT=""
+MAX_ITERATIONS=""
+COMPLETION_PROMISE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --max-iterations)
+      MAX_ITERATIONS="$2"
+      shift 2
+      ;;
+    --completion-promise)
+      COMPLETION_PROMISE="$2"
+      shift 2
+      ;;
+    *)
+      # Accumulate as prompt (strip surrounding quotes if present)
+      if [ -z "$PROMPT" ]; then
+        PROMPT="$1"
+      else
+        PROMPT="$PROMPT $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Strip surrounding quotes from prompt
+PROMPT=$(echo "$PROMPT" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/")
+
+# Validate required argument
+if [ -z "$PROMPT" ]; then
+  echo "Error: Prompt is required" >&2
+  echo "Usage: /ralph \"<prompt>\" [--max-iterations N] [--completion-promise \"<text>\"]" >&2
+  exit 1
+fi
+
+# Validate max-iterations is numeric
+if [ -n "$MAX_ITERATIONS" ] && ! [[ "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
+  echo "Error: --max-iterations must be a number" >&2
+  exit 1
+fi
+
+# Check if loop is already active
+if [ -f "$STATE_FILE" ]; then
+  CURRENT_ITERATION=$(grep '^iteration:' "$STATE_FILE" | sed 's/^iteration: *//')
+  echo "Warning: Ralph loop already active at iteration $CURRENT_ITERATION" >&2
+  echo "Use /cancel-ralph to stop the current loop first" >&2
+  exit 1
+fi
+
+# Create state directory if needed
+mkdir -p "$STATE_DIR"
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+# Create state file with YAML frontmatter
+cat > "$STATE_FILE" << EOF
+---
+iteration: 1
+max_iterations: ${MAX_ITERATIONS:-}
+completion_promise: ${COMPLETION_PROMISE:-}
+started_at: $(date -Iseconds)
+---
+$PROMPT
+EOF
+
+# Create progress file
+cat > "$PROGRESS_FILE" << EOF
+# Ralph Progress - Ephemeral session memory
+# Patterns promote to AGENTS.md at loop end
+
+started_at: $(date -Iseconds)
+branch: ${CURRENT_BRANCH}
+
+patterns: {}
+  # Add discovered patterns here, e.g.:
+  # migrations: "Use IF NOT EXISTS for all column additions"
+  # forms: "Zod schema validation"
+
+stories: []
+  # Append completed stories here
+EOF
+
+# Display startup message
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║                    🔄 RALPH LOOP STARTED                       ║"
+echo "╠════════════════════════════════════════════════════════════════╣"
+echo "║ Iteration: 1${MAX_ITERATIONS:+ of $MAX_ITERATIONS}                                                    "
+if [ -n "$COMPLETION_PROMISE" ]; then
+echo "║ Completion: Output <promise>$COMPLETION_PROMISE</promise> when done"
+fi
+echo "╠════════════════════════════════════════════════════════════════╣"
+echo "║ Progress: .claude/ralph-progress.local.yml                     ║"
+echo "║ Monitor:  grep '^iteration:' .claude/ralph-loop.local.md       ║"
+echo "╠════════════════════════════════════════════════════════════════╣"
+echo "║ ⚠️  Use /cancel-ralph to stop the loop manually                ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Instructions for Claude
+cat << 'EOF'
+---
+
+**RALPH LOOP ACTIVE**
+
+## Before Starting Work
+
+1. Read `.claude/ralph-progress.local.yml` for accumulated patterns
+2. Check patterns section for project-specific learnings
+
+## After Completing Each Story
+
+Update `.claude/ralph-progress.local.yml`:
+
+```yaml
+patterns:
+  <key>: "<learning>"  # Add new patterns discovered
+
+stories:
+  - id: <story-id>
+    title: <title>
+    completed_at: <timestamp>
+    files:
+      - <file1>
+      - <file2>
+    learnings:
+      - "<specific learning>"
+```
+
+## Completion Rule
+
+EOF
+
+if [ -n "$COMPLETION_PROMISE" ]; then
+  echo "Output \`<promise>$COMPLETION_PROMISE</promise>\` ONLY when genuinely complete."
+  echo "Do NOT output false promises to escape the loop."
+  echo ""
+fi
+
+echo "---"
+echo ""
+echo "**TASK:**"
+echo ""
+echo "$PROMPT"

--- a/plugins/majestic-ralph/skills/ralph-methodology/SKILL.md
+++ b/plugins/majestic-ralph/skills/ralph-methodology/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: ralph-methodology
+description: Best practices for autonomous AI coding loops - task breakdown, prompt writing, and learnings that compound
+triggers:
+  - ralph
+  - autonomous loop
+  - ship while sleeping
+  - iteration loop
+---
+
+# Ralph Methodology
+
+Patterns for effective autonomous AI coding loops.
+
+## Core Principles
+
+| Principle | Implementation |
+|-----------|----------------|
+| **Small Stories** | Each task fits in one context window |
+| **Fast Feedback** | Tests + typecheck validate each iteration |
+| **Explicit Criteria** | Acceptance criteria, not vague goals |
+| **Learnings Compound** | Patterns accumulate in progress file |
+| **Iteration > Perfection** | Let the loop refine, don't aim for perfect first try |
+
+## Task Size Rules
+
+```
+# Too big - spans multiple concerns
+❌ "Build entire auth system"
+
+# Right size - focused, verifiable
+✅ "Add login form with email/password fields"
+✅ "Add email format validation"
+✅ "Add auth server action"
+✅ "Add session management"
+```
+
+**Heuristic:** If you can't verify it with a single test run, it's too big.
+
+## Acceptance Criteria Format
+
+```markdown
+## Story: Add login form
+
+**Acceptance Criteria:**
+- [ ] Email and password input fields
+- [ ] Client-side email format validation
+- [ ] Submit button disabled until valid
+- [ ] Error message on invalid submission
+- [ ] typecheck passes
+- [ ] Tests pass
+- [ ] Verify at localhost:3000/login
+
+**Output `<promise>DONE</promise>` when ALL criteria met.**
+```
+
+## Progress File
+
+Location: `.claude/ralph-progress.local.yml` (gitignored)
+
+```yaml
+started_at: 2024-01-15T10:30:00Z
+branch: feature/auth
+
+patterns:
+  migrations: "Use IF NOT EXISTS for all column additions"
+  forms: "Zod schema validation, errors in schema not component"
+  auth: "Server actions in actions.ts, session in httpOnly cookie"
+  tests: "Use vitest, not jest"
+
+stories:
+  - id: US-001
+    title: Add login form
+    completed_at: 2024-01-15T10:45:00Z
+    files:
+      - app/login/page.tsx
+      - app/auth/actions.ts
+    learnings:
+      - "Form validation uses zod"
+      - "Submit handler in separate action file"
+
+  - id: US-002
+    title: Add validation
+    completed_at: 2024-01-15T11:02:00Z
+    files:
+      - app/login/page.tsx
+    learnings:
+      - "Zod .email() handles format validation"
+```
+
+### Progress File Rules
+
+1. **Read first** — Check patterns before starting each iteration
+2. **Append after** — Add story entry after completing each task
+3. **Patterns at top** — Key-value pairs for quick reference
+4. **Promote at end** — Move valuable patterns to AGENTS.md when loop completes
+
+### How Learnings Compound
+
+| Iteration | What Claude Sees |
+|-----------|------------------|
+| 1 | Empty patterns |
+| 2 | Patterns from story 1 |
+| 5 | Patterns from stories 1-4 |
+| 10 | Rich pattern library |
+
+## AGENTS.md (Permanent Memory)
+
+Durable patterns for humans and future agents:
+
+```markdown
+# app/auth/
+
+## Patterns
+- Server actions in `actions.ts`, not inline
+- Use zod schemas for form validation
+- Session stored in httpOnly cookie
+
+## Gotchas
+- Must call `revalidatePath` after auth changes
+- Token refresh handled by middleware
+```
+
+**Promote from progress file at loop end.**
+
+## Feedback Loop Requirements
+
+**Mandatory:** Fast, automated verification each iteration.
+
+| Check | Purpose | Example |
+|-------|---------|---------|
+| Typecheck | Catch type errors | `npm run typecheck` |
+| Tests | Verify behavior | `npm test` |
+| Lint | Code quality | `npm run lint` |
+| Build | Catch build issues | `npm run build` |
+
+**Without feedback loops, broken code compounds.**
+
+## Prompt Templates
+
+### Basic Autonomous Loop
+
+```
+Implement: [TASK TITLE]
+
+Acceptance Criteria:
+- [Criterion 1]
+- [Criterion 2]
+- typecheck passes
+- tests pass
+
+Update .claude/ralph-progress.local.yml with patterns discovered.
+Output <promise>COMPLETE</promise> when ALL criteria met.
+```
+
+### With TDD
+
+```
+Implement [FEATURE] following TDD:
+1. Write failing tests first
+2. Implement minimum code to pass
+3. Run typecheck and tests
+4. If any fail, debug and fix
+5. Refactor if needed
+6. Repeat until all green
+
+Update progress file with learnings.
+Output <promise>COMPLETE</promise> when tests pass.
+```
+
+### With Escape Hatch
+
+```
+Implement [FEATURE].
+
+After 15 iterations, if not complete:
+- Document what's blocking progress
+- List approaches attempted
+- Suggest alternatives
+- Output <promise>BLOCKED</promise>
+
+Otherwise, output <promise>COMPLETE</promise> when done.
+```
+
+### Multi-Phase
+
+```
+Build [SYSTEM] in phases:
+
+Phase 1: [Component A] - tests passing
+Phase 2: [Component B] - tests passing
+Phase 3: [Integration] - all tests passing
+
+Update progress file after each phase.
+Output <promise>COMPLETE</promise> when all phases done.
+```
+
+## Common Gotchas
+
+### Idempotent Operations
+
+```sql
+-- Always use IF NOT EXISTS for migrations
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email TEXT;
+```
+
+### Non-Interactive Commands
+
+```bash
+# Pipe input to avoid interactive prompts
+echo -e "\n\n\n" | npm run db:generate
+
+# Use --yes flags where available
+npm init -y
+```
+
+### Schema Cascade
+
+After editing schema, check ALL dependent code:
+- Server actions
+- UI components
+- API routes
+- Tests
+
+**Fixing related files is expected, not scope creep.**
+
+## When NOT to Use Ralph
+
+| Scenario | Why |
+|----------|-----|
+| Exploratory work | No clear success criteria |
+| Major refactors | Needs human architecture decisions |
+| Security-critical | Requires careful human review |
+| Production debugging | Too risky for autonomous changes |
+| Design decisions | Subjective, needs human judgment |
+
+## Monitoring Commands
+
+```bash
+# Current iteration
+grep '^iteration:' .claude/ralph-loop.local.md
+
+# View progress
+cat .claude/ralph-progress.local.yml
+
+# Recent commits
+git log --oneline -10
+```
+
+## Integration with Blueprints
+
+Use Ralph with `/majestic:run-blueprint` for multi-task features:
+
+```bash
+/ralph "/majestic:run-blueprint docs/plans/add-auth.md" --max-iterations 50 --completion-promise "RUN_BLUEPRINT_COMPLETE"
+```
+
+The blueprint provides:
+- Task breakdown with dependencies
+- Structured progress tracking
+- Quality gates per task
+- Batch shipping at end


### PR DESCRIPTION
## Summary

- Add new `majestic-ralph` plugin for autonomous AI coding loops
- Ships features while you sleep with iterative prompts that compound learnings
- Replaces external dependency on `ralph-loop` plugin

## What's Included

### Commands
- `/ralph "<prompt>"` - Start an iteration loop
- `/cancel-ralph` - Stop active loop
- `/ralph-help` - Documentation and best practices

### Infrastructure
- Stop hook that intercepts session exit and re-feeds prompts
- YAML progress file for compound learnings
- ralph-methodology skill with task sizing, prompt templates

## What Makes This Different

| Feature | Other Implementations | majestic-ralph |
|---------|----------------------|----------------|
| **Progress format** | Markdown (unstructured) | YAML (structured, parseable) |
| **Git handling** | Committed to history | Gitignored → promotes to AGENTS.md |
| **Pattern access** | Buried in narrative | Top-level `patterns:` key |
| **Blueprint integration** | None | Built-in via `/majestic:run-blueprint` |

### Key Innovation: Ephemeral → Permanent Memory

```
During loop:     .claude/ralph-progress.local.yml  (gitignored, working memory)
                              ↓
After loop:      AGENTS.md patterns section         (committed, permanent)
```

## Changes

- `plugins/majestic-ralph/` - New plugin (3 commands, 1 skill, 1 hook)
- `plugins/majestic-engineer/commands/workflows/run-blueprint.md` - Use internal ralph
- `.claude-plugin/marketplace.json` - Add majestic-ralph, bump to v3.3.0

## Test plan

- [ ] Install plugin and run `/ralph-help`
- [ ] Start a simple loop with `/ralph "echo test" --max-iterations 3`
- [ ] Verify progress file created at `.claude/ralph-progress.local.yml`
- [ ] Test `/cancel-ralph` stops the loop
- [ ] Verify `/majestic:run-blueprint` uses internal ralph