### PR TITLE
feat(relay): add relay process status tracking

### DIFF
--- a/plugins/majestic-relay/commands/init.md
+++ b/plugins/majestic-relay/commands/init.md
@@ -157,6 +157,8 @@ Write to `.majestic/attempt-ledger.yml`:
 version: 1
 epic_id: "{epic.id}"
 started_at: "{ISO timestamp}"
+ended_at: null           # Set when epic completes
+duration_minutes: null   # Calculated on completion
 
 settings:
   max_attempts_per_task: {MAX_ATTEMPTS}

--- a/plugins/majestic-relay/commands/status.md
+++ b/plugins/majestic-relay/commands/status.md
@@ -43,6 +43,9 @@ Epic: {EPIC.id} ({COMPLETED}/{TOTAL_TASKS} tasks complete)
 Source: {EPIC.source}
 Started: {LEDGER.started_at}
 
+If LEDGER.ended_at exists:
+  Print: "Completed: {LEDGER.ended_at} ({LEDGER.duration_minutes} min)"
+
 Progress: [████████░░░░░░░░░░░░] {percentage}%
 ```
 

--- a/plugins/majestic-relay/scripts/relay-work.sh
+++ b/plugins/majestic-relay/scripts/relay-work.sh
@@ -131,8 +131,12 @@ while true; do
     TOTAL=$(yq -r '.tasks | keys | length' "$EPIC")
 
     if [[ "$COMPLETED" -eq "$TOTAL" ]]; then
+      # Record epic completion with timing
+      ledger_epic_complete
+
+      DURATION=$(yq -r '.duration_minutes // 0' "$LEDGER")
       echo ""
-      echo -e "${GREEN}✅ Epic complete! ($COMPLETED/$TOTAL tasks)${NC}"
+      echo -e "${GREEN}✅ Epic complete! ($COMPLETED/$TOTAL tasks in ${DURATION} min)${NC}"
       ledger_relay_stop 0 "epic_complete"
       exit 0
     else


### PR DESCRIPTION
## Summary

Track relay process status and epic/task timing.

### Feature 1: Relay Process Status

Track whether relay is currently running, when it last ran, and why it stopped.

**New ledger fields:**
```yaml
relay_status:
  state: idle | running
  pid: 12345  # when running
  started_at: "2026-01-12T16:00:00-06:00"
  stopped_at: "2026-01-12T16:30:00-06:00"
  last_exit_code: 0 | 1
  last_exit_reason: epic_complete | no_runnable_tasks | interrupted | crashed
```

**Status display:**
```
Relay: 🟢 running (PID 12345)
# or
Relay: ⏸️ no_runnable_tasks (5 min ago)
```

### Feature 2: Epic/Task Timing

Track when epic started, ended, and total duration.

**New ledger fields:**
```yaml
started_at: "2026-01-12T09:15:00-06:00"
ended_at: "2026-01-12T16:30:00-06:00"
duration_minutes: 435
```

**Completion message:**
```
✅ Epic complete! (46/46 tasks in 435 min)
```

## Changes

- `scripts/lib/ledger.sh`: 
  - Relay status helpers (+65 lines)
  - Epic timing helpers (+50 lines)
- `relay-work.sh`: Track state on start/stop, record epic completion
- `status.md`: Display relay status and epic timing
- `init.md`: Include all new fields in ledger template

## Test plan
- [ ] Run `/relay:work` and check status shows "running"
- [ ] Stop relay (Ctrl+C) and verify status shows "interrupted"
- [ ] Complete epic and verify `ended_at` and `duration_minutes` set
- [ ] Check completion message shows duration
- [ ] Verify stale PID detection works after crash