### PR TITLE
Fix RepoPrompt code review integration in relay workflow

### DIFF
--- a/plugins/majestic-relay/.claude-plugin/plugin.json
+++ b/plugins/majestic-relay/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "majestic-relay",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Fresh-context task execution with attempt ledger. Shell-orchestrated epic workflow with re-anchoring and gating.",
   "author": {
     "name": "David Paluy",

--- a/plugins/majestic-relay/agents/rp-reviewer.md
+++ b/plugins/majestic-relay/agents/rp-reviewer.md
@@ -1,0 +1,90 @@
+---
+name: rp-reviewer
+description: Code review using RepoPrompt MCP (chat_send mode=review). Returns structured verdict for relay workflow.
+---
+
+# Purpose
+
+Review code changes using RepoPrompt MCP. Returns structured JSON verdict.
+
+## Input Schema
+
+```yaml
+task_id: string           # Task identifier (T1, T2, etc.)
+changed_files: string[]   # List of changed file paths
+```
+
+## Output Schema
+
+```json
+{
+  "verdict": "approved" | "rejected",
+  "reason": "string"
+}
+```
+
+## Process
+
+### 1. Switch RepoPrompt Workspace
+
+Ensure RepoPrompt is on the correct workspace for the project:
+
+```
+Call repoprompt/manage_workspaces with:
+{
+  "action": "switch",
+  "workspace": "<project-name>"
+}
+```
+
+### 2. Call RepoPrompt chat_send
+
+Use `repoprompt/chat_send` MCP tool with review mode:
+
+```json
+{
+  "new_chat": true,
+  "mode": "review",
+  "selected_paths": ["<changed-files>"],
+  "message": "Review code changes for task <task_id>. Check for bugs, security issues, code quality. If acceptable, respond APPROVED. Otherwise list issues.",
+  "chat_name": "relay-review-<task_id>"
+}
+```
+
+**Key:** `mode: "review"` includes git diffs automatically via gitInclusion.
+
+### 3. Parse Response
+
+| Response Pattern | Verdict |
+|-----------------|---------|
+| Contains "NOT APPROVED" or "DISAPPROVED" | rejected |
+| Contains "APPROVED" (without negation) | approved |
+| No clear verdict | rejected |
+
+### 4. Return Structured Result
+
+```json
+{
+  "verdict": "approved",
+  "reason": "Code review passed - no issues found"
+}
+```
+
+Or on rejection:
+
+```json
+{
+  "verdict": "rejected",
+  "reason": "Security vulnerability found in auth.rb:45"
+}
+```
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| RepoPrompt MCP not available | Return `{ "verdict": "approved", "reason": "RepoPrompt unavailable" }` |
+| Workspace switch fails | Return `{ "verdict": "approved", "reason": "Could not switch workspace" }` |
+| chat_send fails | Return `{ "verdict": "approved", "reason": "Review failed - auto-approved" }` |
+
+**Design principle:** Fail-open to avoid blocking relay workflow.


### PR DESCRIPTION
## Summary

- Replace broken mcp-cli approach with Claude native MCP access
- Add rp-reviewer agent using repoprompt/chat_send with mode=review
- Use structured JSON output for reliable verdict parsing
- Remove external mcp-cli dependency (uses claude CLI instead)
- Bump relay plugin version to 1.0.5

## What's Fixed

The original repoprompt review integration was calling a non-existent `repoprompt/review` MCP tool, which failed silently and auto-approved all reviews.

**New approach:**
- Shell script invokes `claude -p` (Claude headless mode)
- Claude uses native MCP access to:
  1. Switch RepoPrompt workspace via `repoprompt/manage_workspaces`
  2. Call `repoprompt/chat_send` with `mode="review"` (includes git diffs automatically)
  3. Return structured JSON verdict
- Shell script parses JSON and continues relay workflow

## Files Changed

- `plugins/majestic-relay/agents/rp-reviewer.md` - New agent documenting review workflow
- `plugins/majestic-relay/scripts/lib/review.sh` - Fixed run_repoprompt_review() to use claude -p
- `plugins/majestic-relay/.claude-plugin/plugin.json` - Version bump to 1.0.5

## Test Plan

- [x] Code review via RepoPrompt now works (tested with RepoPrompt logs)
- [x] MCP integration properly switches workspaces
- [x] Structured JSON output parses correctly
- [x] Fail-open behavior preserved (approves on any error)
- [ ] Manual test with full relay workflow