### PR TITLE
fix(relay): handle Claude CLI errors with JSON validation and exit code capture

### DIFF
--- a/plugins/majestic-relay/skills/attempt-ledger/SKILL.md
+++ b/plugins/majestic-relay/skills/attempt-ledger/SKILL.md
@@ -118,7 +118,7 @@ receipt:
 
 ```yaml
 receipt:
-  error_category: missing_dependency | code_error | test_failure | quality_gate
+  error_category: missing_dependency | code_error | test_failure | quality_gate | cli_error
   error_summary: "What went wrong"
   quality_gate_verdict: NEEDS CHANGES | BLOCKED  # If quality gate failed
   quality_gate_findings: |  # Structured findings for retry context


### PR DESCRIPTION
## Summary

- **Detects CLI errors:** Validates JSON output before parsing to catch non-JSON error responses from Claude CLI
- **Captures exit codes properly:** Uses `PIPESTATUS[0]` instead of flawed if/else pattern that was losing exit codes
- **Records failures correctly:** CLI errors become attempt failures with `cli_error` category in ledger
- **Enables retries:** Uses existing 3-attempt mechanism for transient errors that often self-resolve
- **Prevents silent failures:** Previously, non-JSON responses would fail silently in jq parsing

## Why

relay-work.sh had a critical gap in error handling:
1. Piping to `tee` masked the exit code from `claude` command
2. Invalid JSON from CLI errors would silently fail in jq (no error thrown)
3. Undefined variables would continue with partial/garbage data
4. Ledger wouldn't record what actually happened

This fix ensures relay tasks properly detect and record CLI failures, allowing the existing retry mechanism to work as intended for transient errors.

## Changes

### Handle Claude CLI errors with JSON validation
- **What:** Added JSON validation step before attempting to parse CLI output with jq
- **Impact:** If output is invalid JSON, sets `RESULT_STATUS="failure"` and `RESULT_ERROR_CAT="cli_error"`
- **File:** `plugins/majestic-relay/scripts/relay-work.sh` (lines 201-223)

### Capture exit code via PIPESTATUS
- **What:** Changed from if/else pattern to `PIPESTATUS[0]` to properly capture pipe exit code
- **Why:** Piping to `tee` was masking the original exit code; only the tee exit code was visible
- **File:** `plugins/majestic-relay/scripts/relay-work.sh` (line 203)

### Add cli_error to error category enum
- **What:** Extended error_category enum to include `cli_error` option
- **Why:** Allows ledger to distinguish CLI failures from code/test/quality-gate failures
- **File:** `plugins/majestic-relay/skills/attempt-ledger/SKILL.md` (line 121)

## Testing

- [ ] Run relay on existing epic - verify normal tasks still succeed
- [ ] Simulate CLI error (if reproducible) and verify:
  - Error is caught and displayed in relay output
  - Ledger records `error_category: cli_error` in failed attempt
  - Task remains `pending` (not gated) allowing retry
  - After 3 failures, task is properly gated with `max_attempts_exceeded`
- [ ] Verify jq parsing still works for valid JSON responses

## Risk & Rollout

- **Risk:** Low
  - Change is defensive (only handles errors that previously failed anyway)
  - No changes to success path (valid JSON parsing unchanged)
  - Uses existing retry mechanism (3 attempts already in place)
- **Rollback:** Simple revert - no data format changes or dependencies
- **Monitoring:** Watch relay logs for `cli_error` category in early runs to validate fix is working