### PR TITLE
feat(relay): add fix loop with session resume + refactor orchestrator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -440,8 +440,8 @@
     },
     {
       "name": "majestic-relay",
-      "description": "Fresh-context task execution with quality-gate verification and compound learning. Shell-orchestrated epic workflow with re-anchoring, gating, automatic knowledge extraction, and multi-epic playlist orchestration. Includes 6 commands, 1 agent, and 1 skill.",
-      "version": "1.4.5",
+      "description": "Fresh-context task execution with quality-gate verification, fix loop with session resume, and compound learning. Shell-orchestrated epic workflow with re-anchoring, gating, automatic knowledge extraction, and multi-epic playlist orchestration. Includes 6 commands, 1 agent, and 1 skill.",
+      "version": "1.4.6",
       "author": {
         "name": "David Paluy",
         "url": "https://github.com/dpaluy",

--- a/plugins/majestic-relay/.claude-plugin/plugin.json
+++ b/plugins/majestic-relay/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "majestic-relay",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Fresh-context task execution with quality-gate verification and compound learning. Shell-orchestrated epic workflow with re-anchoring, gating, automatic knowledge extraction, and multi-epic playlist orchestration.",
   "author": {
     "name": "David Paluy",

--- a/plugins/majestic-relay/scripts/lib/learning.sh
+++ b/plugins/majestic-relay/scripts/lib/learning.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# learning.sh - Learning extraction from task attempts
+#
+
+# Extract learning from task attempt
+# Usage: extract_learning "$TASK_ID" "$ATTEMPT_ID" "$TASK_TITLE" "$RESULT_STATUS" "$RESULT_MESSAGE" "$RESULT_ERROR_CAT" "$RESULT_SUGGESTION"
+extract_learning() {
+  local task_id="$1"
+  local attempt_id="$2"
+  local task_title="$3"
+  local result_status="$4"
+  local result_message="$5"
+  local result_error_cat="${6:-}"
+  local result_suggestion="${7:-}"
+
+  echo -e "     ${BLUE}📚 Extracting learning...${NC}"
+
+  local context="Task: $task_title
+Result: $result_status
+Summary: $result_message"
+  [[ -n "$result_error_cat" ]] && context="$context
+Error: $result_error_cat"
+  [[ -n "$result_suggestion" ]] && context="$context
+Suggestion: $result_suggestion"
+
+  local prompt="Based on this task attempt, extract ONE reusable learning (1 sentence max).
+Focus on: patterns, gotchas, techniques that apply beyond this specific task.
+
+$context
+
+Output format: LEARNING: <sentence> | TAGS: <comma-separated>
+Or output 'none' if nothing generalizable."
+
+  local output
+  if output=$(claude -p "$prompt" --model haiku 2>/dev/null); then
+    if [[ "$output" != *"none"* ]]; then
+      local learning_text learning_tags
+      learning_text=$(echo "$output" | grep -oE 'LEARNING: [^|]+' | sed 's/LEARNING: //' | head -1)
+      learning_tags=$(echo "$output" | grep -oE 'TAGS: .+' | sed 's/TAGS: //' | head -1)
+
+      if [[ -n "$learning_text" ]]; then
+        ledger_record_learning "$task_id" "$attempt_id" "$learning_text" "$learning_tags"
+        echo -e "     ${GREEN}📝 Learned: ${learning_text:0:60}...${NC}"
+      fi
+    fi
+  fi
+}
+
+# Process learnings at epic completion
+# Usage: process_epic_learnings "$EPIC" "$LEDGER"
+process_epic_learnings() {
+  local epic="$1"
+  local ledger="$2"
+
+  local stats total_learnings epic_id
+  stats=$(ledger_get_learning_stats)
+  total_learnings=$(echo "$stats" | jq -r '.total_learnings // 0')
+
+  if [[ "$total_learnings" -gt 0 ]]; then
+    echo ""
+    echo -e "${BLUE}📚 Processing $total_learnings learnings from epic...${NC}"
+
+    epic_id=$(yq -r '.id' "$epic")
+    local prompt="You are the majestic-relay:learning-processor agent.
+
+Use the workflow defined in your agent spec to:
+1. Read learnings from: $ledger
+2. Consolidate similar patterns
+3. Apply frequency thresholds (1=skip, 2=emerging, 3+=recommend, 4+=strong)
+4. Categorize into AGENTS.md vs .agents.yml
+5. Present findings and ask user before applying changes
+
+Epic: $epic_id
+Ledger: $ledger
+
+Read the ledger and process all learnings. Use AskUserQuestion before making any file changes."
+
+    claude -p "$prompt" --allowedTools 'Read,Write,Edit,Grep,Glob,Bash(yq:*),Bash(grep:*),AskUserQuestion' 2>/dev/null || {
+      echo -e "${YELLOW}⚠️  Learning processor skipped (non-critical)${NC}"
+    }
+  else
+    echo -e "${YELLOW}📝 No learnings captured during epic${NC}"
+  fi
+}

--- a/plugins/majestic-relay/scripts/lib/quality-gate.sh
+++ b/plugins/majestic-relay/scripts/lib/quality-gate.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# quality-gate.sh - Quality gate with fix loop
+#
+
+# Run quality gate with fix loop (up to 2 fix attempts via session resume)
+# Sets: RESULT_STATUS, RESULT_MESSAGE, RESULT_ERROR_CAT on failure
+# Returns: 0=approved, 1=failed, 2=blocked
+# Usage: run_quality_gate "$SESSION_ID" "$TASK_ID" "$TASK_TITLE" "$EPIC"
+run_quality_gate() {
+  local session_id="$1"
+  local task_id="$2"
+  local task_title="$3"
+  local epic="$4"
+  local branch qg_prompt fix_attempt qg_temp qg_output qg_verdict findings
+
+  branch=$(git branch --show-current 2>/dev/null || echo 'unknown')
+  qg_prompt="You are running quality-gate verification for a relay task.
+
+Use the Task tool to invoke the quality-gate agent:
+
+Task(majestic-engineer:workflow:quality-gate):
+  prompt: |
+    Context: ${task_id} - ${task_title}
+    Branch: ${branch}
+    AC Path: ${epic}
+    Task ID: ${task_id}
+
+Return the verdict exactly as: Verdict: APPROVED or Verdict: NEEDS CHANGES or Verdict: BLOCKED"
+
+  fix_attempt=0
+  while [[ $fix_attempt -lt 3 ]]; do
+    echo -e "     ${BLUE}🔍 Running quality gate...${NC}"
+    qg_temp=$(mktemp)
+    claude -p "$qg_prompt" --allowedTools 'Task,Bash(git diff:*),Bash(git status:*),Bash(git log:*),Read,Grep,Glob' 2>&1 | tee "$qg_temp" || true
+    qg_output=$(cat "$qg_temp")
+    rm -f "$qg_temp"
+
+    qg_verdict=$(echo "$qg_output" | grep -oE 'Verdict: (APPROVED|NEEDS CHANGES|BLOCKED)' | tail -1 | cut -d' ' -f2-)
+
+    if [[ "$qg_verdict" == "APPROVED" ]]; then
+      echo -e "     ${GREEN}✅ Quality gate: APPROVED${NC}"
+      return 0
+    elif [[ "$qg_verdict" == "BLOCKED" ]]; then
+      echo -e "     ${RED}🛑 Quality gate: BLOCKED${NC}"
+      return 2
+    elif [[ "$qg_verdict" == "NEEDS CHANGES" ]]; then
+      fix_attempt=$((fix_attempt + 1))
+      if [[ $fix_attempt -ge 3 ]]; then
+        echo -e "     ${RED}❌ Fix attempts exhausted${NC}"
+        RESULT_STATUS="failure"
+        RESULT_MESSAGE="Quality gate failed after 2 fix attempts"
+        RESULT_ERROR_CAT="fix_loop_exhausted"
+        return 1
+      fi
+
+      echo -e "     ${YELLOW}🔧 Fix attempt $fix_attempt/2...${NC}"
+      findings=$(echo "$qg_output" | grep -A 50 "## Finding" || echo "$qg_output" | tail -30)
+
+      if [[ -n "$session_id" ]]; then
+        echo -e "     ${BLUE}↻ Resuming session ${session_id:0:8}...${NC}"
+        claude --resume "$session_id" -p "Fix these quality gate issues:\n\n$findings\n\nMake minimal changes. Run tests. Commit as: fix: address quality gate findings" --permission-mode bypassPermissions 2>&1 || true
+      else
+        claude -p "Fix these quality gate issues:\n\n$findings\n\nMake minimal changes. Run tests. Commit as: fix: address quality gate findings" --permission-mode bypassPermissions 2>&1 || true
+      fi
+    else
+      echo -e "     ${YELLOW}⚠️ Quality gate: unclear verdict${NC}"
+      RESULT_STATUS="failure"
+      RESULT_MESSAGE="Quality gate returned unclear verdict"
+      RESULT_ERROR_CAT="quality_gate"
+      return 1
+    fi
+  done
+}

--- a/plugins/majestic-relay/scripts/lib/task-exec.sh
+++ b/plugins/majestic-relay/scripts/lib/task-exec.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# task-exec.sh - Task execution with JSON output
+#
+
+# Execute task and parse JSON result
+# Sets: RESULT_STATUS, RESULT_MESSAGE, RESULT_FILES, RESULT_ERROR_CAT, RESULT_SUGGESTION, TASK_SESSION_ID
+# Usage: execute_task "$PROMPT" "$SCHEMA"
+execute_task() {
+  local prompt="$1"
+  local schema="$2"
+  local temp_output exit_code output
+
+  temp_output=$(mktemp)
+  echo ""
+  claude -p "$prompt" --permission-mode bypassPermissions --output-format json --json-schema "$schema" 2>&1 | tee "$temp_output" || true
+  exit_code=${PIPESTATUS[0]}
+  echo ""
+
+  output=$(cat "$temp_output")
+  rm -f "$temp_output"
+
+  # Extract session_id for potential fix loop resume
+  TASK_SESSION_ID=$(echo "$output" | jq -r '.session_id // empty' 2>/dev/null)
+
+  # Validate JSON before parsing
+  if ! echo "$output" | jq empty 2>/dev/null; then
+    RESULT_STATUS="failure"
+    RESULT_MESSAGE="CLI error: $(echo "$output" | head -1 | cut -c1-100)"
+    RESULT_FILES=""
+    RESULT_ERROR_CAT="cli_error"
+    RESULT_SUGGESTION="Claude CLI returned non-JSON output (exit code: $exit_code). May be transient."
+    return 1
+  fi
+
+  # Parse structured result
+  RESULT_STATUS=$(echo "$output" | jq -r '.structured_output.status // "failure"')
+  RESULT_MESSAGE=$(echo "$output" | jq -r '.structured_output.summary // "No summary provided"')
+  RESULT_FILES=$(echo "$output" | jq -r '.structured_output.files_changed // [] | join(", ")')
+  RESULT_ERROR_CAT=$(echo "$output" | jq -r '.structured_output.error_category // ""')
+  RESULT_SUGGESTION=$(echo "$output" | jq -r '.structured_output.suggestion // ""')
+}

--- a/plugins/majestic-relay/scripts/relay-work.sh
+++ b/plugins/majestic-relay/scripts/relay-work.sh
@@ -2,10 +2,7 @@
 #
 # relay-work.sh - Fresh-context task execution orchestrator
 #
-# Inspired by: https://github.com/gmickel/gmickel-claude-marketplace (flow-next plugin)
-#
-# Usage:
-#   relay-work.sh [task_id] [--max-attempts N]
+# Usage: relay-work.sh [task_id] [--max-attempts N]
 #
 
 set -euo pipefail
@@ -13,19 +10,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/ledger.sh"
 source "$SCRIPT_DIR/lib/prompt.sh"
+source "$SCRIPT_DIR/lib/task-exec.sh"
+source "$SCRIPT_DIR/lib/quality-gate.sh"
+source "$SCRIPT_DIR/lib/learning.sh"
 
-# File paths
 EPIC=".agents-os/relay/epic.yml"
 LEDGER=".agents-os/relay/attempt-ledger.yml"
 
-# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# JSON schema for task result
 TASK_RESULT_SCHEMA='{
   "type": "object",
   "properties": {
@@ -41,275 +38,116 @@ TASK_RESULT_SCHEMA='{
 # Parse arguments
 SPECIFIC_TASK=""
 MAX_ATTEMPTS_OVERRIDE=""
-
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --max-attempts)
-      MAX_ATTEMPTS_OVERRIDE="$2"
-      shift 2
-      ;;
-    T*)
-      SPECIFIC_TASK="$1"
-      shift
-      ;;
-    *)
-      echo -e "${RED}Unknown option: $1${NC}" >&2
-      exit 1
-      ;;
+    --max-attempts) MAX_ATTEMPTS_OVERRIDE="$2"; shift 2 ;;
+    T*) SPECIFIC_TASK="$1"; shift ;;
+    *) echo -e "${RED}Unknown option: $1${NC}" >&2; exit 1 ;;
   esac
 done
 
 # Check prerequisites
-if [[ ! -f "$EPIC" ]]; then
-  echo -e "${RED}Error: No epic found at $EPIC${NC}" >&2
-  echo "Run '/relay:init <blueprint.md>' first." >&2
-  exit 1
-fi
-
-if [[ ! -f "$LEDGER" ]]; then
-  echo -e "${RED}Error: No ledger found at $LEDGER${NC}" >&2
-  echo "Run '/relay:init <blueprint.md>' to reinitialize." >&2
-  exit 1
-fi
+[[ ! -f "$EPIC" ]] && { echo -e "${RED}Error: No epic found at $EPIC${NC}" >&2; exit 1; }
+[[ ! -f "$LEDGER" ]] && { echo -e "${RED}Error: No ledger found at $LEDGER${NC}" >&2; exit 1; }
 
 # Load settings
 MAX_ATTEMPTS=$(ledger_get_setting "max_attempts_per_task" "3")
-
-# Apply overrides
 [[ -n "$MAX_ATTEMPTS_OVERRIDE" ]] && MAX_ATTEMPTS="$MAX_ATTEMPTS_OVERRIDE"
 
-# Get epic info
-EPIC_ID=$(yq -r '.id' "$EPIC")
-EPIC_TITLE=$(yq -r '.title' "$EPIC")
-
-# Detect and recover from stale state (crashed previous run)
+# Recover from stale state
 if ! ledger_relay_is_running; then
-  # Check for tasks stuck in in_progress
-  STUCK_TASKS=$(yq -r '.task_status | to_entries | .[] | select(.value == "in_progress") | .key' "$LEDGER" 2>/dev/null)
-  if [[ -n "$STUCK_TASKS" ]]; then
+  STUCK=$(yq -r '.task_status | to_entries | .[] | select(.value == "in_progress") | .key' "$LEDGER" 2>/dev/null)
+  if [[ -n "$STUCK" ]]; then
     echo -e "${YELLOW}⚠️  Recovering from crashed state...${NC}"
-    for task_id in $STUCK_TASKS; do
+    for task_id in $STUCK; do
       yq -i ".task_status.${task_id} = \"pending\"" "$LEDGER"
-      echo -e "   Reset ${task_id} to pending"
     done
   fi
 fi
 
-# Track relay process status
 ledger_relay_start
 
-# Cleanup on exit or interrupt
 cleanup() {
-  local exit_code=$?
-  # Only update if not already stopped (avoid double-update)
   local state
   state=$(yq -r '.relay_status.state // "idle"' "$LEDGER" 2>/dev/null)
   if [[ "$state" == "running" ]]; then
-    # Reset any in_progress tasks to pending before stopping
     local stuck
     stuck=$(yq -r '.task_status | to_entries | .[] | select(.value == "in_progress") | .key' "$LEDGER" 2>/dev/null || true)
     for task_id in $stuck; do
       yq -i ".task_status.${task_id} = \"pending\"" "$LEDGER" 2>/dev/null || true
     done
-    ledger_relay_stop "$exit_code" "interrupted"
+    ledger_relay_stop "$?" "interrupted"
   fi
 }
-# Trap signals including SIGPIPE (from broken pipes like head/tail)
 trap cleanup EXIT INT TERM PIPE
 
+EPIC_ID=$(yq -r '.id' "$EPIC")
 echo -e "${BLUE}🚀 Starting epic: ${EPIC_ID}${NC}"
 echo ""
 
-# Main execution loop
+# Main loop
 while true; do
-  # Find next executable task
+  # Find next task
   if [[ -n "$SPECIFIC_TASK" ]]; then
     NEXT_TASK="$SPECIFIC_TASK"
-    # Clear specific task after first iteration
     SPECIFIC_TASK=""
   else
     NEXT_TASK=$(find_next_task "$EPIC" "$LEDGER")
   fi
 
+  # Handle completion or no tasks
   if [[ -z "$NEXT_TASK" ]]; then
-    # Check if all done or all blocked/gated
     COMPLETED=$(ledger_count_status "completed")
     TOTAL=$(yq -r '.tasks | keys | length' "$EPIC")
 
     if [[ "$COMPLETED" -eq "$TOTAL" ]]; then
-      # Record epic completion with timing
       ledger_epic_complete
-
       DURATION=$(yq -r '.duration_minutes // 0' "$LEDGER")
-      echo ""
       echo -e "${GREEN}✅ Epic complete! ($COMPLETED/$TOTAL tasks in ${DURATION} min)${NC}"
-
-      # Run compound learning aggregation
-      LEARNING_STATS=$(ledger_get_learning_stats)
-      TOTAL_LEARNINGS=$(echo "$LEARNING_STATS" | jq -r '.total_learnings // 0')
-
-      if [[ "$TOTAL_LEARNINGS" -gt 0 ]]; then
-        echo ""
-        echo -e "${BLUE}📚 Processing $TOTAL_LEARNINGS learnings from epic...${NC}"
-
-        EPIC_ID=$(yq -r '.id' "$EPIC")
-
-        LEARNING_PROMPT="You are the majestic-relay:learning-processor agent.
-
-Use the workflow defined in your agent spec to:
-1. Read learnings from: $LEDGER
-2. Consolidate similar patterns
-3. Apply frequency thresholds (1=skip, 2=emerging, 3+=recommend, 4+=strong)
-4. Categorize into AGENTS.md vs .agents.yml
-5. Present findings and ask user before applying changes
-
-Epic: $EPIC_ID
-Ledger: $LEDGER
-
-Read the ledger and process all learnings. Use AskUserQuestion before making any file changes."
-
-        # Run learning processor (interactive - user confirms changes)
-        claude -p "$LEARNING_PROMPT" --allowedTools 'Read,Write,Edit,Grep,Glob,Bash(yq:*),Bash(grep:*),AskUserQuestion' 2>/dev/null || {
-          echo -e "${YELLOW}⚠️  Learning processor skipped (non-critical)${NC}"
-        }
-      else
-        echo -e "${YELLOW}📝 No learnings captured during epic${NC}"
-      fi
-
+      process_epic_learnings "$EPIC" "$LEDGER"
       ledger_relay_stop 0 "epic_complete"
       exit 0
     else
       GATED=$(yq -r '.gated_tasks | keys | length' "$LEDGER")
-      echo ""
       echo -e "${YELLOW}⏸️  No executable tasks remaining${NC}"
       echo "  Completed: $COMPLETED/$TOTAL"
       [[ "$GATED" -gt 0 ]] && echo -e "  ${RED}Gated: $GATED tasks${NC}"
-      echo ""
-      echo "Run '/relay:status --verbose' for details."
       ledger_relay_stop 1 "no_runnable_tasks"
       exit 1
     fi
   fi
 
-  # Get task info
   TASK_TITLE=$(yq -r ".tasks.${NEXT_TASK}.title" "$EPIC")
-
-  # Check attempt count
   ATTEMPTS=$(ledger_count_attempts "$NEXT_TASK")
 
+  # Check attempt limit
   if [[ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]]; then
-    echo -e "${RED}🚫 Gating $NEXT_TASK: max attempts exceeded ($ATTEMPTS/$MAX_ATTEMPTS)${NC}"
+    echo -e "${RED}🚫 Gating $NEXT_TASK: max attempts exceeded${NC}"
     ledger_gate_task "$NEXT_TASK" "max_attempts_exceeded"
     continue
   fi
 
-  # Start new attempt
   ATTEMPT_ID=$((ATTEMPTS + 1))
   echo -e "${BLUE}[$NEXT_TASK]${NC} $TASK_TITLE"
   echo -e "     Attempt $ATTEMPT_ID/$MAX_ATTEMPTS..."
 
   ledger_record_attempt_start "$NEXT_TASK" "$ATTEMPT_ID"
 
-  # Build re-anchoring prompt
+  # Execute task
   PROMPT=$(build_task_prompt "$EPIC" "$LEDGER" "$NEXT_TASK")
+  execute_task "$PROMPT" "$TASK_RESULT_SCHEMA"
 
-  # Spawn fresh Claude instance with JSON output
-  # Use tee to stream output to terminal while capturing to temp file
-  TEMP_OUTPUT=$(mktemp)
-  trap "rm -f $TEMP_OUTPUT" RETURN
-
-  echo ""
-  claude -p "$PROMPT" --permission-mode bypassPermissions --output-format json --json-schema "$TASK_RESULT_SCHEMA" 2>&1 | tee "$TEMP_OUTPUT" || true
-  CLAUDE_EXIT_CODE=${PIPESTATUS[0]}
-  echo ""
-
-  OUTPUT=$(cat "$TEMP_OUTPUT")
-  rm -f "$TEMP_OUTPUT"
-
-  # Validate JSON before parsing
-  if ! echo "$OUTPUT" | jq empty 2>/dev/null; then
-    RESULT_STATUS="failure"
-    RESULT_MESSAGE="CLI error: $(echo "$OUTPUT" | head -1 | cut -c1-100)"
-    RESULT_FILES=""
-    RESULT_ERROR_CAT="cli_error"
-    RESULT_SUGGESTION="Claude CLI returned non-JSON output (exit code: $CLAUDE_EXIT_CODE). May be transient."
-  else
-    # Parse structured result with jq (from structured_output field)
-    RESULT_STATUS=$(echo "$OUTPUT" | jq -r '.structured_output.status // "failure"')
-    RESULT_MESSAGE=$(echo "$OUTPUT" | jq -r '.structured_output.summary // "No summary provided"')
-    RESULT_FILES=$(echo "$OUTPUT" | jq -r '.structured_output.files_changed // [] | join(", ")')
-    RESULT_ERROR_CAT=$(echo "$OUTPUT" | jq -r '.structured_output.error_category // ""')
-    RESULT_SUGGESTION=$(echo "$OUTPUT" | jq -r '.structured_output.suggestion // ""')
-  fi
-
-  # Run quality gate (replaces old review step)
-  # Quality gate verifies AC + runs configured reviewers
+  # Quality gate on success
   if [[ "$RESULT_STATUS" == "success" ]]; then
-    echo -e "     ${BLUE}🔍 Running quality gate...${NC}"
-
-    # Build quality gate prompt
-    # Quality gate agent expects: Context, Branch, AC Path, Task ID
-    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo 'unknown')
-
-    QG_PROMPT="You are running quality-gate verification for a relay task.
-
-Use the Task tool to invoke the quality-gate agent:
-
-Task(majestic-engineer:workflow:quality-gate):
-  prompt: |
-    Context: ${NEXT_TASK} - ${TASK_TITLE}
-    Branch: ${CURRENT_BRANCH}
-    AC Path: ${EPIC}
-    Task ID: ${NEXT_TASK}
-
-Return the verdict exactly as: Verdict: APPROVED or Verdict: NEEDS CHANGES or Verdict: BLOCKED"
-
-    # Call quality-gate via Claude (stream output)
-    QG_TEMP=$(mktemp)
-    echo ""
-    if claude -p "$QG_PROMPT" --allowedTools 'Task,Bash(git diff:*),Bash(git status:*),Bash(git log:*),Read,Grep,Glob' 2>&1 | tee "$QG_TEMP"; then
-      QG_OUTPUT=$(cat "$QG_TEMP")
-      rm -f "$QG_TEMP"
-      # Parse verdict from output (look for "Verdict: APPROVED/NEEDS CHANGES/BLOCKED")
-      QG_VERDICT=$(echo "$QG_OUTPUT" | grep -oE 'Verdict: (APPROVED|NEEDS CHANGES|BLOCKED)' | tail -1 | cut -d' ' -f2-)
-
-      case "$QG_VERDICT" in
-        "APPROVED")
-          echo -e "     ${GREEN}✅ Quality gate: APPROVED${NC}"
-          RESULT_STATUS="success"
-          ;;
-        "NEEDS CHANGES")
-          echo -e "     ${YELLOW}⚠️ Quality gate: NEEDS CHANGES${NC}"
-          RESULT_STATUS="failure"
-          RESULT_MESSAGE="Quality gate requires changes"
-          RESULT_ERROR_CAT="quality_gate"
-          # Extract findings for next attempt
-          RESULT_SUGGESTION=$(echo "$QG_OUTPUT" | grep -A 100 "### Required Fixes" | head -50)
-          ;;
-        "BLOCKED")
-          echo -e "     ${RED}🛑 Quality gate: BLOCKED${NC}"
-          # Gate the task immediately - critical issues found
-          ledger_gate_task "$NEXT_TASK" "quality_gate_blocked"
-          echo ""
-          continue
-          ;;
-        *)
-          # Fallback: if no clear verdict, treat as needs review
-          echo -e "     ${YELLOW}⚠️ Quality gate: unclear verdict, treating as needs changes${NC}"
-          RESULT_STATUS="failure"
-          RESULT_MESSAGE="Quality gate returned unclear verdict"
-          RESULT_ERROR_CAT="quality_gate"
-          ;;
-      esac
-    else
-      # Quality gate failed to run - log warning but don't block
-      rm -f "$QG_TEMP"
-      echo -e "     ${YELLOW}⚠️ Quality gate agent failed, using self-reported status${NC}"
-    fi
+    run_quality_gate "$TASK_SESSION_ID" "$NEXT_TASK" "$TASK_TITLE" "$EPIC"
+    QG_RESULT=$?
+    case $QG_RESULT in
+      2) ledger_gate_task "$NEXT_TASK" "quality_gate_blocked"; continue ;;
+    esac
     echo ""
   fi
 
-  # Update ledger with receipt
+  # Record result
   if [[ "$RESULT_STATUS" == "success" ]]; then
     echo -e "     ${GREEN}✅ Task complete${NC}"
     ledger_record_attempt_success "$NEXT_TASK" "$ATTEMPT_ID" "$RESULT_MESSAGE" "$RESULT_FILES"
@@ -318,37 +156,6 @@ Return the verdict exactly as: Verdict: APPROVED or Verdict: NEEDS CHANGES or Ve
     ledger_record_attempt_failure "$NEXT_TASK" "$ATTEMPT_ID" "$RESULT_MESSAGE" "$RESULT_ERROR_CAT" "$RESULT_SUGGESTION"
   fi
 
-  # Extract learning from attempt (compound learning)
-  echo -e "     ${BLUE}📚 Extracting learning...${NC}"
-  LEARNING_CONTEXT="Task: $TASK_TITLE
-Result: $RESULT_STATUS
-Summary: $RESULT_MESSAGE"
-  [[ -n "$RESULT_ERROR_CAT" ]] && LEARNING_CONTEXT="$LEARNING_CONTEXT
-Error: $RESULT_ERROR_CAT"
-  [[ -n "$RESULT_SUGGESTION" ]] && LEARNING_CONTEXT="$LEARNING_CONTEXT
-Suggestion: $RESULT_SUGGESTION"
-
-  LEARNING_PROMPT="Based on this task attempt, extract ONE reusable learning (1 sentence max).
-Focus on: patterns, gotchas, techniques that apply beyond this specific task.
-
-$LEARNING_CONTEXT
-
-Output format: LEARNING: <sentence> | TAGS: <comma-separated>
-Or output 'none' if nothing generalizable."
-
-  LEARNING_OUTPUT=""
-  if LEARNING_OUTPUT=$(claude -p "$LEARNING_PROMPT" --model haiku 2>/dev/null); then
-    # Parse learning and tags
-    if [[ "$LEARNING_OUTPUT" != *"none"* ]]; then
-      LEARNING_TEXT=$(echo "$LEARNING_OUTPUT" | grep -oE 'LEARNING: [^|]+' | sed 's/LEARNING: //' | head -1)
-      LEARNING_TAGS=$(echo "$LEARNING_OUTPUT" | grep -oE 'TAGS: .+' | sed 's/TAGS: //' | head -1)
-
-      if [[ -n "$LEARNING_TEXT" ]]; then
-        ledger_record_learning "$NEXT_TASK" "$ATTEMPT_ID" "$LEARNING_TEXT" "$LEARNING_TAGS"
-        echo -e "     ${GREEN}📝 Learned: ${LEARNING_TEXT:0:60}...${NC}"
-      fi
-    fi
-  fi
-
+  extract_learning "$NEXT_TASK" "$ATTEMPT_ID" "$TASK_TITLE" "$RESULT_STATUS" "$RESULT_MESSAGE" "$RESULT_ERROR_CAT" "$RESULT_SUGGESTION"
   echo ""
 done


### PR DESCRIPTION
## Summary

- Add quality gate fix loop that resumes build session up to 2 times before failing
- Refactor relay-work.sh (353 → 161 lines) by extracting to focused libraries
- Each concern now has single responsibility: task execution, QG + fixes, learning extraction
- Bump version 1.4.5 → 1.4.6

## Why

**Problem:** When quality gate found issues, relay halted and required manual intervention. Each retry was a fresh session that lost context.

**Solution:** Resume the same session that built the feature. It already knows what it built - just tell it what to fix. Attempt up to 2 fixes before failing the attempt.

**Code Quality:** relay-work.sh was 353 lines with mixed concerns. Libraries now have single responsibility, max 85 lines each. Easier to test and maintain.

## Changes

### Quality Gate with Fix Loop
- Parse QG verdict: APPROVED (done) | BLOCKED (gate task) | NEEDS CHANGES (attempt fix)
- On NEEDS CHANGES: resume the build session (has full context)
- Loop up to 2 times, then fail
- Run QG after each fix to verify

### Refactoring
- **lib/task-exec.sh** (42 lines): Run claude, parse JSON, capture session_id
- **lib/quality-gate.sh** (74 lines): QG + fix loop with session resume
- **lib/learning.sh** (85 lines): Extract learnings and process at epic completion
- **relay-work.sh** (161 lines): Orchestration only - main loop, task dispatch, state management

## Testing

Verify in bina/:
- [ ] `/relay:work` runs epic successfully
- [ ] On QG NEEDS CHANGES, outputs "Fix attempt 1/2..."
- [ ] Session resumes (check session ID in output)
- [ ] QG re-runs and approves after fix
- [ ] Exhausted fixes fail with "Fix loop exhausted"
- [ ] BLOCKED verdict gates task immediately

## Risk & Rollout

- **Risk:** Low - additive feature, existing behavior unchanged if QG approves on first try
- **Rollback:** Revert commit, no data migrations needed
- **Monitoring:** Check relay ledger for "fix_loop_exhausted" error category post-launch

Closes #56