### PR TITLE
feat: migrate from TodoWrite to native Claude Code Tasks

### DIFF
--- a/plugins/majestic-company/agents/ceo/ai-advantage.md
+++ b/plugins/majestic-company/agents/ceo/ai-advantage.md
@@ -2,7 +2,7 @@
 name: ai-advantage
 description: Develop research-backed AI competitive strategies combining academic research, market trends, and social sentiment analysis
 color: purple
-tools: Read, Write, Edit, WebSearch, WebFetch, AskUserQuestion, TodoWrite, mcp__perplexity-ask__perplexity_ask
+tools: Read, Write, Edit, WebSearch, WebFetch, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, mcp__perplexity-ask__perplexity_ask
 ---
 
 # AI Competitive Advantage Research

--- a/plugins/majestic-company/agents/ceo/growth-audit.md
+++ b/plugins/majestic-company/agents/ceo/growth-audit.md
@@ -2,7 +2,7 @@
 name: growth-audit
 description: 360-degree business audit to 5-10X growth trajectory. Evidence-backed analysis with 0-10 scoring across 6 dimensions, benchmarking vs winners/laggards, bottleneck prioritization by impact x ease, and week-by-week 90-day roadmap.
 color: purple
-tools: WebSearch, WebFetch, Read, Write, AskUserQuestion, TodoWrite
+tools: WebSearch, WebFetch, Read, Write, AskUserQuestion, TaskCreate, TaskList, TaskUpdate
 ---
 
 # Growth Audit

--- a/plugins/majestic-company/agents/ceo/industry-research.md
+++ b/plugins/majestic-company/agents/ceo/industry-research.md
@@ -2,7 +2,7 @@
 name: industry-research
 description: Research a market, pinpoint an underserved customer pain, and design a venture that can capture the opportunity within 12 months. Comprehensive 10-step workflow from market mapping to 90-day action plan.
 color: purple
-tools: WebSearch, WebFetch, AskUserQuestion, TodoWrite
+tools: WebSearch, WebFetch, AskUserQuestion, TaskCreate, TaskList, TaskUpdate
 ---
 
 # Industry Research

--- a/plugins/majestic-company/agents/ceo/startup-blueprint.md
+++ b/plugins/majestic-company/agents/ceo/startup-blueprint.md
@@ -2,7 +2,7 @@
 name: startup-blueprint
 description: Interactive 10-phase startup planning tailored to skills, budget, and goals.
 color: purple
-tools: WebSearch, WebFetch, AskUserQuestion, TodoWrite, Write
+tools: WebSearch, WebFetch, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, Write
 ---
 
 # Startup Blueprint Generator

--- a/plugins/majestic-company/agents/idea-validator.md
+++ b/plugins/majestic-company/agents/idea-validator.md
@@ -2,7 +2,7 @@
 name: idea-validator
 description: Validate startup ideas through research delivering GO/NO-GO verdict with market analysis.
 color: purple
-tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, TodoWrite
+tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, TaskCreate, TaskList, TaskUpdate
 ---
 
 # Idea Validator Agent
@@ -55,7 +55,7 @@ I'll run real research and give you an honest assessment."
 
 ### Step 3: Execute Research Phases
 
-Track progress with `TodoWrite`. For each phase:
+Track progress with `TaskCreate` and `TaskUpdate`. For each phase:
 
 **Phase 1: Problem Validation**
 - Search G2, Capterra, TrustRadius for competitor reviews

--- a/plugins/majestic-company/agents/problem-research.md
+++ b/plugins/majestic-company/agents/problem-research.md
@@ -2,7 +2,7 @@
 name: problem-research
 description: Research competitor pain points from review platforms (G2, Capterra, Reddit) to find wedge opportunities. SaaS/B2B focus. Use for market validation, competitive analysis, or deciding whether to build.
 color: orange
-tools: Read, Write, Edit, WebSearch, WebFetch, AskUserQuestion, TodoWrite, mcp__browsermcp__*
+tools: Read, Write, Edit, WebSearch, WebFetch, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, mcp__browsermcp__*
 ---
 
 # Problem Research
@@ -65,7 +65,7 @@ Ask user which execution approach to use:
 
 ### Phase 4: Execute Research
 
-Track progress via TodoWrite through these steps:
+Track progress via TaskCreate/TaskUpdate through these steps:
 
 1. **Identify top competitors** - Find 3-10 players based on scope
 2. **Analyze review platforms** - G2, Capterra, TrustRadius per competitor

--- a/plugins/majestic-engineer/agents/plan/architect.md
+++ b/plugins/majestic-engineer/agents/plan/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Design non-trivial features with architectural planning. Transforms requirements into implementation approaches and system designs.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, WebSearch, WebFetch, TodoWrite, mcp__sequential-thinking
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, WebSearch, WebFetch, TaskCreate, TaskList, TaskUpdate, mcp__sequential-thinking
 color: blue
 ---
 

--- a/plugins/majestic-engineer/agents/qa/test-create.md
+++ b/plugins/majestic-engineer/agents/qa/test-create.md
@@ -1,7 +1,7 @@
 ---
 name: test-create
 description: Write automated tests with RSpec, Minitest, or Jest. Creates test plan, writes comprehensive tests, runs verification, and reports coverage.
-tools: Read, Grep, Glob, Write, MultiEdit, Bash, WebFetch, Skill, TodoWrite
+tools: Read, Grep, Glob, Write, MultiEdit, Bash, WebFetch, Skill, TaskCreate, TaskList, TaskUpdate
 color: red
 ---
 
@@ -67,7 +67,7 @@ When invoked, you must follow these steps:
      - **Checklist format**: Simple features, clear scenarios, sequential logic
      - **Tabular format**: Multi-parameter functions, decision tables, boundary value analysis, API endpoints with varied inputs
    - Present the test plan to confirm coverage before implementation
-   - Use TodoWrite to track test cases to be implemented as you write them
+   - Use TaskCreate to track test cases to be implemented as you write them
 
 6. **Invoke Appropriate Testing Skill** (For Ruby/Rails tests)
    - If framework is **RSpec**, use the Skill tool to invoke `rspec-coder`
@@ -82,7 +82,7 @@ When invoked, you must follow these steps:
 
 7. **Write Test Implementation** (Following the test plan)
    - Implement tests according to the test plan from step 5
-   - Use TodoWrite to mark test cases as completed as you write them
+   - Use TaskUpdate to mark test cases as completed as you write them
    - Follow the testing skill's guidance for Ruby/Rails tests
    - For **Rails Integration Tests**: Test full request/response cycles, database transactions, and user workflows
    - For **Model/Service/API Tests**: Test business logic, validations, scopes, callbacks, and service object behaviors

--- a/plugins/majestic-engineer/agents/session-checkpoint.md
+++ b/plugins/majestic-engineer/agents/session-checkpoint.md
@@ -207,13 +207,13 @@ Mark assumptions as `UNCONFIRMED` when:
 
 **Guideline**: After 2-3 compactions in a session, checkpoint to ledger and `/clear` for fresh context with preserved state.
 
-## Ledger vs Handoff vs TodoWrite
+## Ledger vs Handoff vs Tasks
 
 | Tool | Purpose | Persistence | Trigger |
 |------|---------|-------------|---------|
 | `session-checkpoint` | Crash recovery, quick state save | File (`.agents-os/session_ledger.md`) | Agent-triggered |
 | `/session:handoff` | Cross-session continuity | File (main worktree `.agents-os/handoffs/`) | User/ship-triggered |
-| `TodoWrite` | In-session task tracking | In-context only | Agent-triggered |
+| `Tasks` | Session task tracking | File (`~/.claude/tasks/`) | Agent-triggered |
 
 Use `session-checkpoint` for:
 - Automated state preservation during workflows

--- a/plugins/majestic-engineer/commands/workflows/build-task.md
+++ b/plugins/majestic-engineer/commands/workflows/build-task.md
@@ -2,7 +2,7 @@
 name: majestic:build-task
 description: Autonomous task implementation - research, plan, build, review, fix, ship
 argument-hint: "<task-reference or plan-file>"
-allowed-tools: Bash, Read, Grep, Glob, WebFetch, TodoWrite, Task, Skill
+allowed-tools: Bash, Read, Grep, Glob, WebFetch, TaskCreate, TaskList, TaskUpdate, Task, Skill
 ---
 
 # Build Task

--- a/plugins/majestic-engineer/skills/backlog-manager/SKILL.md
+++ b/plugins/majestic-engineer/skills/backlog-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backlog-manager
-description: Manage backlog items across multiple backends (files, GitHub Issues, Linear, Beads). Configure task_management in .agents.yml.
+description: Manage backlog items across multiple backends (GitHub Issues, Linear, Beads). Configure task_management in .agents.yml.
 ---
 
 # Backlog Manager Skill
@@ -13,17 +13,18 @@ The backlog manager provides a unified interface for tracking work items across 
 
 | Backend | Integration | Best For |
 |---------|-------------|----------|
-| **Files** | Local markdown in `docs/todos/` | Solo developers, simple projects |
 | **GitHub** | `gh` CLI | Teams using GitHub Issues |
 | **Linear** | MCP server | Teams using Linear |
 | **Beads** | `bd` CLI | Dependency-aware workflows, AI agents |
+
+**For simple/solo projects:** Use native Tasks (`TaskCreate`, `TaskList`, `TaskUpdate`) instead of backlog-manager.
 
 ## Configuration
 
 Configure your preferred backend in your project's `.agents.yml`:
 
 ```yaml
-task_management: github  # Options: file, github, linear, beads
+task_management: github  # Options: github, linear, beads
 
 # Workflow labels (for github/linear backends)
 workflow_labels:
@@ -36,7 +37,7 @@ workflow_labels:
 # beads_prefix: myapp               # Optional: custom issue prefix
 ```
 
-**Default:** If no configuration is found, uses file-based backend.
+**Default:** If no configuration is found, use native Tasks (`TaskCreate`, `TaskList`, `TaskUpdate`) for simple tracking.
 
 ## When to Use This Skill
 
@@ -96,7 +97,6 @@ When this skill is invoked:
 
 1. **Read configuration** from project CLAUDE.md
 2. **Load appropriate reference** based on `backend` setting:
-   - `files` → `references/file-backend.md`
    - `github` → `references/github-backend.md`
    - `linear` → `references/linear-backend.md`
    - `beads` → `references/beads-backend.md`
@@ -105,9 +105,9 @@ When this skill is invoked:
 ### Fallback Behavior
 
 If the configured backend is unavailable:
-- **GitHub unavailable** (gh not authenticated): Fall back to files
-- **Linear unavailable** (MCP not configured): Fall back to files
-- **Beads unavailable** (bd not installed or not initialized): Fall back to files
+- **GitHub unavailable** (gh not authenticated): Fall back to native Tasks
+- **Linear unavailable** (MCP not configured): Fall back to native Tasks
+- **Beads unavailable** (bd not installed or not initialized): Fall back to native Tasks
 - **Warn user** about the fallback
 
 ## Integration with Development Workflows
@@ -128,8 +128,9 @@ If the configured backend is unavailable:
 - Team collaboration
 - Project/sprint planning
 
-**TodoWrite tool:**
-- In-memory task tracking during single session
-- Temporary progress tracking
-- Not persisted to disk
-- Different purpose from backlog management
+**Native Tasks (TaskCreate, TaskList, TaskUpdate):**
+- Session task tracking with file persistence (`~/.claude/tasks/`)
+- Supports dependencies (`blockedBy`, `blocks`)
+- Can be shared across sessions via `CLAUDE_CODE_TASK_LIST_ID` env var
+- Use for: in-session progress tracking, subagent coordination, simple task lists
+- Different from backlog manager: Tasks are ephemeral coordination, backlog is project planning

--- a/plugins/majestic-engineer/skills/subagent-driven-development/SKILL.md
+++ b/plugins/majestic-engineer/skills/subagent-driven-development/SKILL.md
@@ -31,7 +31,7 @@ Execute plan by dispatching fresh subagent per task, with code review after each
 
 ### 1. Load Plan
 
-Read plan file, create TodoWrite with all tasks.
+Read plan file, use TaskCreate to create all tasks.
 
 ### 2. Execute Task with Subagent
 
@@ -88,7 +88,7 @@ Task tool (superpowers:code-reviewer):
 
 ### 5. Mark Complete, Next Task
 
-- Mark task as completed in TodoWrite
+- Use TaskUpdate to mark task as completed
 - Move to next task
 - Repeat steps 2-5
 
@@ -111,7 +111,7 @@ After final review passes:
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
 
-[Load plan, create TodoWrite]
+[Load plan, create tasks via TaskCreate]
 
 Task 1: Hook installation script
 

--- a/plugins/majestic-rails/commands/workflows/build.md
+++ b/plugins/majestic-rails/commands/workflows/build.md
@@ -2,7 +2,7 @@
 name: rails:build
 description: Execute work plans efficiently while maintaining quality and finishing Rails features
 argument-hint: "[plan file] [optional: branch-name]"
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite, Task
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TaskCreate, TaskList, TaskUpdate, Task
 ---
 
 # Work Plan Execution Command
@@ -70,8 +70,8 @@ Parse the arguments to extract:
    - You're working on a single feature
    - You prefer staying in the main repository
 
-3. **Create Todo List**
-   - Use TodoWrite to break plan into actionable tasks
+3. **Create Task List**
+   - Use TaskCreate to break plan into actionable tasks
    - Include dependencies between tasks
    - Prioritize based on what needs to be done first
    - Include testing and quality check tasks
@@ -85,7 +85,7 @@ Parse the arguments to extract:
 
    ```
    while (tasks remain):
-     - Mark task as in_progress in TodoWrite
+     - Use TaskUpdate to mark task as in_progress
      - Read any referenced files from the plan
      - Look for similar patterns in codebase
      - Implement following existing conventions
@@ -119,7 +119,7 @@ Parse the arguments to extract:
    - Repeat until implementation meets expectations
 
 5. **Track Progress**
-   - Keep TodoWrite updated as you complete tasks
+   - Use TaskUpdate to mark tasks completed as you finish them
    - Note any blockers or unexpected discoveries
    - Create new tasks if scope expands
    - Keep user informed of major milestones
@@ -158,7 +158,7 @@ Parse the arguments to extract:
    Present findings to user and address critical issues.
 
 3. **Final Validation**
-   - All TodoWrite tasks marked completed
+   - All tasks marked completed via TaskUpdate
    - All tests pass
    - Linting passes
    - Code follows existing patterns
@@ -222,7 +222,7 @@ After shipping, notify the user:
 Before creating PR, verify:
 
 - [ ] All clarifying questions asked and answered
-- [ ] All TodoWrite tasks marked completed
+- [ ] All tasks marked completed via TaskUpdate
 - [ ] Tests pass (run `bin/rails test`)
 - [ ] Linting passes (use `lint` agent)
 - [ ] Code follows existing patterns
@@ -248,6 +248,6 @@ For most features: tests + linting + following patterns is sufficient.
 - **Skipping clarifying questions** - Ask now, not after building wrong thing
 - **Ignoring plan references** - The plan has links for a reason
 - **Testing at the end** - Test continuously or suffer later
-- **Forgetting TodoWrite** - Track progress or lose track of what's done
+- **Forgetting task tracking** - Use TaskUpdate or lose track of what's done
 - **80% done syndrome** - Finish the feature, don't move on early
 - **Over-reviewing simple changes** - Save reviewer agents for complex work

--- a/plugins/majestic-react/agents/plan/react-architect.md
+++ b/plugins/majestic-react/agents/plan/react-architect.md
@@ -2,7 +2,7 @@
 name: react-architect
 description: Design React application architecture and component hierarchies. Plans state management, folder structure, and performance optimization strategies.
 color: purple
-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, TodoWrite
+tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, TaskCreate, TaskList, TaskUpdate
 ---
 
 # React Architect

--- a/plugins/majestic-relay/commands/init.md
+++ b/plugins/majestic-relay/commands/init.md
@@ -111,7 +111,27 @@ relay_status:
 
 Write to `.agents-os/relay/attempt-ledger.yml`
 
-### 6. Output Summary
+### 6. Create Native Tasks
+
+Create Claude Code Tasks from epic tasks for real-time coordination:
+
+```
+EPIC_ID = "relay-$(date +%y%m%d%H%M%S)"  # e.g., "relay-260122195930"
+export CLAUDE_CODE_TASK_LIST_ID="${EPIC_ID}"
+
+For each task in first_epic.tasks:
+  TaskCreate:
+    subject: task.title
+    description: task.spec
+    metadata: { epic_id: EPIC_ID, task_id: task.id, phase: task.phase }
+
+  If task.depends_on:
+    TaskUpdate: blockedBy = [dependency_task_ids]
+```
+
+**Note:** Native Tasks provide real-time progress visibility. Ledger provides detailed attempt history.
+
+### 7. Output Summary
 
 ```
 ✅ Initialized from: {blueprint_path}

--- a/plugins/majestic-relay/commands/work.md
+++ b/plugins/majestic-relay/commands/work.md
@@ -26,6 +26,21 @@ If not exists(".agents-os/relay/attempt-ledger.yml"):
 Execute: "${CLAUDE_PLUGIN_ROOT}/scripts/relay-work.sh" $ARGUMENTS
 ```
 
+## Task Coordination
+
+Workers share a TaskList via environment variable:
+
+```bash
+export CLAUDE_CODE_TASK_LIST_ID="relay-${EPIC_ID}"
+```
+
+Workers can discover and log additional work:
+- Use `TaskCreate` for discovered work outside current task scope
+- Continue with current task - do NOT block on discoveries
+- Orchestrator sees discovered tasks after worker completes
+
+**Note:** Ledger tracks detailed attempt receipts. Tasks enable worker-to-orchestrator communication.
+
 ## Error Handling
 
 | Scenario | Action |

--- a/plugins/majestic-relay/scripts/lib/prompt.sh
+++ b/plugins/majestic-relay/scripts/lib/prompt.sh
@@ -141,6 +141,12 @@ The task has already been planned and approved at the blueprint stage. Your job 
 - Run tests
 - Commit changes
 
+**Task discovery:**
+If you discover work that should be tracked but is outside this task's scope:
+- Use TaskCreate with subject describing the discovered work
+- Continue with your current task - do NOT block
+- The orchestrator will see discovered tasks after you complete
+
 Your response will be automatically structured as JSON. The orchestrator captures your result status.
 EOF
 }

--- a/plugins/majestic-relay/scripts/relay-work.sh
+++ b/plugins/majestic-relay/scripts/relay-work.sh
@@ -85,6 +85,9 @@ EPIC_ID=$(yq -r '.id' "$EPIC")
 echo -e "${BLUE}🚀 Starting epic: ${EPIC_ID}${NC}"
 echo ""
 
+# Share TaskList across worker instances for real-time coordination
+export CLAUDE_CODE_TASK_LIST_ID="relay-${EPIC_ID}"
+
 # Main loop
 while true; do
   # Find next task


### PR DESCRIPTION
## Summary

- Replaced deprecated `TodoWrite` tool with native Claude Code Tasks (`TaskCreate`, `TaskList`, `TaskUpdate`)
- Updated 19 files across 6 plugins with uniform pattern for task coordination
- Integrated Tasks into majestic-relay for real-time progress tracking
- Added Task Coordination documentation to headless-mode skill

## Why

Claude Code evolved with Tasks as the native task coordination primitive, replacing TodoWrite. Adoption ensures:
- **Consistency**: Uniform pattern across marketplace (not mixing old/new approaches)
- **Future-proof**: Leverage built-in features (dependencies, file persistence, multi-session sharing)
- **Better subagent coordination**: Bi-directional ownership (parent creates, subagents can escalate discoveries)
- **Relay integration**: Real-time task progress for epic execution without manual state management

## Changes

### 1. Updated allowed-tools declarations (11 files)
Replaced `TodoWrite` with `TaskCreate, TaskList, TaskUpdate`:
- `plugins/majestic-rails/commands/workflows/build.md`
- `plugins/majestic-engineer/commands/workflows/build-task.md`
- `plugins/majestic-engineer/agents/plan/architect.md`
- `plugins/majestic-engineer/agents/qa/test-create.md`
- `plugins/majestic-react/agents/plan/react-architect.md`
- `plugins/majestic-company/agents/{idea-validator, startup-blueprint, ai-advantage, industry-research, growth-audit, problem-research}.md`

### 2. Rewrote instruction text (5 files)
Updated prose from "Use TodoWrite to..." to Task-based patterns:
- `plugins/majestic-rails/commands/workflows/build.md` (6 references)
- `plugins/majestic-engineer/skills/subagent-driven-development/SKILL.md` (3 references)
- `plugins/majestic-engineer/agents/qa/test-create.md` (2 references)
- `plugins/majestic-company/agents/idea-validator.md`, `problem-research.md`

### 3. Updated documentation (2 files)
- `plugins/majestic-engineer/agents/session-checkpoint.md`: Updated "Ledger vs Handoff vs TodoWrite" comparison table → "Ledger vs Handoff vs Tasks"
- `plugins/majestic-engineer/skills/backlog-manager/SKILL.md`: Deprecated file backend, clarified Tasks relationship, updated fallback behavior

### 4. Added Task Coordination to headless-mode skill
- `.claude/skills/claude-headless-mode/SKILL.md`: New section documenting `CLAUDE_CODE_TASK_LIST_ID` env var pattern for orchestrator + workers

### 5. Integrated Tasks into majestic-relay
- `plugins/majestic-relay/commands/init.md`: Added step to create native Tasks from epic.yml tasks with dependencies
- `plugins/majestic-relay/commands/work.md`: Documented task coordination workflow via TaskUpdate
- `plugins/majestic-relay/scripts/relay-work.sh`: Set `CLAUDE_CODE_TASK_LIST_ID` env var, mark tasks in_progress/completed
- `plugins/majestic-relay/scripts/lib/prompt.sh`: Added task discovery pattern (subagents can create discovered tasks non-blocking)

## Testing

- [ ] Verify no TodoWrite references remain: `grep -r 'TodoWrite' plugins/ .claude/` → empty
- [ ] Run existing agent workflows (build-task, subagent-driven-dev) to verify Task tools are recognized
- [ ] Test relay init → creates native Tasks with proper metadata
- [ ] Verify relay work → marks tasks in_progress/completed via native Tools
- [ ] Test headless pattern: `export CLAUDE_CODE_TASK_LIST_ID=test && claude -p "TaskCreate" && claude -p "TaskList"` → both invocations share state

## Risk & Rollout

- **Risk:** Low - Pure tooling replacement with no behavioral change to existing workflows
  - Tasks are native (no dependency on marketplace code)
  - Fallback works: if Tasks unavailable, agents would just not have those tools available
  - Agents still function without Tasks (just missing progress tracking)
- **Rollback:** Simple `git revert` if needed; TodoWrite could be re-added to allowed-tools without breaking existing Tasks code
- **Monitoring:** 
  - Watch for "tool not found" errors if any agents fail to recognize Task tools
  - Verify relay epic execution creates Tasks and marks progress correctly
  - No performance impact expected (Tasks are lightweight)

---

Closes #migration from TodoWrite