### PR TITLE
feat(engineer): add headless-quality-gate agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "majestic-engineer",
       "description": "Language-agnostic engineering workflows. Includes 35 specialized agents, 26 commands, 27 skills, and 5 toolbox presets.",
-      "version": "3.56.0",
+      "version": "3.57.0",
       "author": {
         "name": "David Paluy",
         "url": "https://github.com/dpaluy",

--- a/plugins/majestic-engineer/.claude-plugin/plugin.json
+++ b/plugins/majestic-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "majestic-engineer",
-  "version": "3.56.0",
+  "version": "3.57.0",
   "description": "Language-agnostic engineering workflows. Includes 35 specialized agents, 26 commands, 27 skills, and 5 toolbox presets.",
   "author": {
     "name": "David Paluy",


### PR DESCRIPTION
## Summary

- Add `headless-quality-gate` agent that runs reviewers in parallel headless Claude processes
- Designed for Anthropic-style code review where each reviewer gets fresh context
- Receives AC content directly (pure function, caller extracts AC)
- Enforces detailed actionable findings via JSON schema

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| AC as parameter (not path) | Pure function semantics, caller controls source |
| JSON schema enforcement | Guarantees parseable, actionable output |
| Detailed findings required | Fix loop needs file:line, current vs expected, fix instruction |
| Parallel bash processes | True OS-level parallelism via `claude -p ... &` |
| `--permission-mode plan` | Read-only review, no writes during review |

## Test plan

- [ ] Verify agent loads without errors
- [ ] Test with sample AC content and branch
- [ ] Verify JSON output matches schema
- [ ] Test parallel execution with multiple reviewers