### PR TITLE
feat(marketing): add JSON-LD, density formula, priority matrix to 3 skills

### DIFF
--- a/plugins/majestic-marketing/skills/content-refresher/SKILL.md
+++ b/plugins/majestic-marketing/skills/content-refresher/SKILL.md
@@ -30,17 +30,11 @@ Identify update opportunities in existing content to maintain freshness and rele
 
 ## Refresh Priority Matrix
 
-**High Priority (Immediate):**
-- Pages losing rankings (>3 positions)
-- Content with outdated information
-- High-traffic pages declining
-- Seasonal content approaching
-
-**Medium Priority (This Month):**
-- Stagnant rankings (6+ months)
-- Competitor content updates
-- Missing current trends
-- Low engagement metrics
+| Priority | Criteria | Action Window |
+|----------|----------|---------------|
+| **High** | Pages losing 3+ ranking positions; factually outdated info; high-traffic pages declining; seasonal content approaching | Update within 1 week |
+| **Medium** | Stagnant rankings 6+ months; competitors published fresher content; missing current trends; low engagement metrics | Update this month |
+| **Low** | Minor date references; cosmetic freshness signals; supplementary examples | Batch in next content cycle |
 
 ## Process
 

--- a/plugins/majestic-marketing/skills/keyword-strategist/SKILL.md
+++ b/plugins/majestic-marketing/skills/keyword-strategist/SKILL.md
@@ -27,6 +27,18 @@ Analyze content for semantic optimization opportunities and keyword strategy.
 - Entity co-occurrence patterns
 - Semantic variations for diversity
 
+## Density Formula
+
+```
+density = (keyword_occurrences / total_words) * 100
+```
+
+Worked example (1,500-word article):
+- "project management" appears 12 times → 0.8% — OK
+- "best software" appears 45 times → 3.0% — flag for revision (over-optimized)
+
+If primary keyword density exceeds 2%, list specific sentences for rewrite.
+
 ## Entity Analysis Framework
 
 1. Identify primary entity relationships

--- a/plugins/majestic-marketing/skills/snippet-hunter/SKILL.md
+++ b/plugins/majestic-marketing/skills/snippet-hunter/SKILL.md
@@ -71,6 +71,51 @@ Format content for position zero potential and featured snippet eligibility.
 - Point 3 (additional value)
 ```
 
+## Schema Markup (copy-paste ready)
+
+**FAQPage JSON-LD:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is [topic]?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[40-60 word direct answer]"
+      }
+    }
+  ]
+}
+```
+
+**HowTo JSON-LD:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to [action]",
+  "description": "[1-2 sentence summary]",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "[Step name]",
+      "text": "[Step description, 1-2 sentences]"
+    }
+  ]
+}
+```
+
+## Validation Checklist
+
+- Paragraph answer is 40-60 words
+- Question appears as H2 or H3 header
+- Answer starts immediately after the header (no preamble)
+- List items are concise (under 15 words each)
+- Table has clean markdown formatting with header row
+
 **Deliverables:**
 - Snippet-optimized content blocks
 - PAA question/answer pairs


### PR DESCRIPTION
## Summary

Additive improvements to three marketing skills. Cherry-picks the genuinely useful concrete content from #79 and discards everything else from that PR.

| Skill | Change |
|-------|--------|
| `snippet-hunter` | + FAQPage and HowTo JSON-LD blocks (copy-paste), validation checklist |
| `keyword-strategist` | + density formula, worked numeric example with OK/over-optimized thresholds |
| `content-refresher` | priority list → structured matrix with criteria and action windows |

All three skills retain their existing focus areas, deliverables, freshness signals, entity-analysis framework, and platform-implementation sections. Net diff is +62 / -11 lines.

## What this PR deliberately does NOT do

- Does not edit `plugins/majestic-engineer/skills/relay/attempt-ledger/` — that skill was removed from master in `d546f56`.
- Does not remove `argument-hint` from `config-reader/SKILL.md` — `argument-hint` is documented in `plugins/majestic-tools/skills/skill-structure/SKILL.md` and used in 10+ skills.
- Does not strip "Freshness Signals", "Platform Implementation", "Entity Analysis Framework", or "Advanced Tactics" sections — those are concrete, project-specific content that the repo's own skill rules tell us to keep.
- Does not add a third-party `tesslio/skill-review` GitHub Action.

## Validation

Ran `bash .claude/skills/skill-linter/scripts/validate-skill.sh` against all three modified skills:

- `snippet-hunter`: 13 passed, 0 failed, 1 pre-existing warning
- `keyword-strategist`: 13 passed, 0 failed, 1 pre-existing warning
- `content-refresher`: 13 passed, 0 failed, 1 pre-existing warning

The single warning ("Description lacks routing keywords") is pre-existing on master and out of scope for this PR.

## Test plan

- [ ] Manually invoke `/snippet-hunter` style prompts and confirm JSON-LD blocks render correctly
- [ ] Skim `keyword-strategist` density formula for math correctness
- [ ] Verify `content-refresher` matrix renders cleanly in the skill UI

## Credit

Source ideas come from #79 by @rohan-tessl. This PR extracts the ~15% of that diff that is concretely useful and leaves the rest.